### PR TITLE
README: add aarch64 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,19 @@ A simpler container for deploying bootable container images.
 
 ## Example
 
+x86_64:
 ```
 mkdir output
 sudo podman run --rm -it --privileged --security-opt label=type:unconfined_t -v $(pwd)/output:/output ghcr.io/osbuild/osbuild-deploy-container quay.io/centos-boot/fedora-tier-1:eln
 
 qemu-system-x86_64 -M accel=kvm -cpu host -smp 2 -m 4096 -bios /usr/share/OVMF/OVMF_CODE.fd -snapshot output/qcow2/disk.qcow2
+```
+
+aarch64:
+```
+mkdir output
+podman run --rm -it --privileged --security-opt label=type:unconfined_t -v $(pwd)/output:/output ghcr.io/osbuild/osbuild-deploy-container -imageref quay.io/centos-bootc/fedora-bootc
+qemu-system-aarch64 -M accel=hvf -cpu host -smp 2 -m 4096 -bios /opt/homebrew/Cellar/qemu/8.1.3_2/share/qemu/edk2-aarch64-code.fd -snapshot output/qcow2/disk.qcow2 -serial stdio -machine virt
 ```
 
 ## Volumes


### PR DESCRIPTION
This should not be merged quite yet. Firstly, there is no aarch64 version of osbulid-deploy-container in our container registry, so it needs to be built locally. Secondly, the bootable container we pull in is currently `:latest`, but should be `:eln` (which does not yet exist).