### PR TITLE
Create users and groups defined in config

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
@@ -53,6 +54,9 @@ func pipelines(imgref string, config *BuildConfig, architecture arch.Arch, rng *
 	if config != nil && config.Blueprint != nil {
 		customizations = config.Blueprint.Customizations
 	}
+
+	img.Users = users.UsersFromBP(customizations.GetUsers())
+	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
 	img.KernelOptionsAppend = []string{
 		"rw",

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -3,7 +3,7 @@ module github.com/osbuild/bootc-image-builder/bib
 go 1.19
 
 require (
-	github.com/osbuild/images v0.21.0
+	github.com/osbuild/images v0.22.0
 	github.com/spf13/cobra v1.8.0
 )
 

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -209,6 +209,8 @@ github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bl
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/osbuild/images v0.21.0 h1:xqW7Y6F+ihoL8x2J+S3nGDRXIqZPq//c0Q8ny3afdpo=
 github.com/osbuild/images v0.21.0/go.mod h1:HtKiCjR4gQcqcd8E7i37orlFqhsjZmFCvyM89E3aeos=
+github.com/osbuild/images v0.22.0 h1:r5Vgzce8fVQNWgtp3m+09nM5Jd2zoLwQfH6kWHtWgrE=
+github.com/osbuild/images v0.22.0/go.mod h1:izbGogyK8gkrvYHVfcyQEBiY0r1xhSj48hjrK92VMzI=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Pull in the latest osbuild/images and set the users and groups from the customizations on the image config to create the appropriate stages during deployment.