### PR TITLE
HMS-3162: tests: add initial testing farm integration

### DIFF
--- a/.github/workflows/testingfarm.yml
+++ b/.github/workflows/testingfarm.yml
@@ -1,0 +1,52 @@
+---
+name: Testing farm tests
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# To use testing farm we need the TF_API_KEY secret available inside the
+# forked repo which requires the pull_request_target trigger. To protect
+# the secrets we need to make sure only people with repo write access
+# can trigger this workflow. This means that ouside contributors will
+# get an initial failure when the workflow is run. But once someone from
+# the team re-triggers it it will work.
+#
+# Note that "pull_requqest_target" events are always triggered even
+# when the "Fork pull request workflows from outside collaborators"
+# setting is restricted to "Require approval for all outside collaborators"
+# (see https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)
+#
+# Note also that this precautions might be overkill because a fork
+# cannot modify this workflow and all we do is run a branch inside
+# testing farm. But a) the scope of workflow may expand over time
+# b) it feels safer this way and is not a big burden in practise.
+#
+# This follows https://michaelheap.com/access-secrets-from-forks/
+jobs:
+  testingfarm:
+    name: "Run in testing farm"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get User Permission
+      id: checkAccess
+      uses: actions-cool/check-user-permission@v2
+      with:
+        require: write
+        username: ${{ github.triggering_actor }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check User Permission
+      if: steps.checkAccess.outputs.require-result == 'false'
+      run: |
+        echo "${{ github.triggering_actor }} does not have permissions on this repo."
+        echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+        echo "Job originally triggered by ${{ github.actor }}"
+        exit 1
+    - name: Run the tests
+      uses: sclorg/testing-farm-as-github-action@v1
+      with:
+        api_key: ${{ secrets.TF_API_KEY }}
+        git_url: ${{ github.event.pull_request.head.repo.clone_url }}
+        git_ref: ${{ github.event.pull_request.head.ref }}
+        pull_request_status_name: "Testing farm"


### PR DESCRIPTION
This adds initial testing farm integration via a github action. To run jobs on testing farm a token is required that is stored as a repository secret. For security reasons repository secrets are not visible accross forks [0].

There are multiple ways to work around this limiation, this commit goes with the suggestion from [1], i.e.: the workflow is run within the `pull_request_target` trigger which has access to secrets.

This means the (potentially untrusted) branch is only checked out if the person triggering the workflow has already write access to the repository (we could make this restriction strong but it seems a reasonable permisson level). In practise the workflow will fail for outside contributions but a re-trigger from anyone in the term should be enough to get it tested inside the testing farm.

[0] https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
[1] https://michaelheap.com/access-secrets-from-forks/