### PR TITLE
github: update `compose:` value for testing farm GH action

### DIFF
--- a/.github/workflows/testingfarm.yml
+++ b/.github/workflows/testingfarm.yml
@@ -50,6 +50,7 @@ jobs:
     - name: Run the tests
       uses: sclorg/testing-farm-as-github-action@v1
       with:
+        compose: Fedora-39
         api_key: ${{ secrets.TF_API_KEY }}
         git_url: ${{ github.event.pull_request.head.repo.clone_url }}
         git_ref: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
In order to use nested virtualizaton we need to use the `Red Hat Ranch` from testing farm. The testing farm token is now updated in the github secrets. However the default value of the `sclorg/testing-farm-as-github-action@v1` action is to use `compose: Fedora-latest`. According to:
https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_composes this is not available in the RH ranch so we need to use something else.

I picked `Fedora-39` for now but happy about alternative ideas (`CentOS-Stream-9` might also be an option?).