### PR TITLE
tests: actually log into the generated disk image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
       uses: actions/setup-python@v4
     - name: Install test dependencies
       run: |
-        sudo apt install -y podman python3-pytest flake8 qemu-system-x86
+        sudo apt install -y podman python3-pytest python3-paramiko flake8 qemu-system-x86
     - name: Run tests
       run: |
         # podman needs (parts of) the environment but will break when

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -11,6 +11,7 @@ prepare:
     - podman
     - pytest
     - python3-flake8
+    - python3-paramiko
     - qemu-kvm
 execute:
   how: tmt

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -92,6 +92,8 @@ def test_smoke(output_path, config_json):
         print("WARNING: selinux not enabled, cannot check for denials")
 
     with VM(generated_img) as test_vm:
-        # TODO: replace with 'test_vm.run("true")' once user creation via
-        #       blueprints works
-        test_vm.wait_ssh_ready()
+        exit_status, _ = test_vm.run("true", user="test", password="password")
+        assert exit_status == 0
+        exit_status, output = test_vm.run("echo hello", user="test", password="password")
+        assert exit_status == 0
+        assert "hello" in output


### PR DESCRIPTION
This commit adds an integration test that ensures that the generated
disk can be logged into via ssh by the blueprint user.

Build on top of https://github.com/osbuild/bootc-image-builder/pull/34