### PR TITLE
github: don't skip the build pipeline on README-only PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,6 @@ name: Build containers
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "README.md"
   workflow_dispatch:
   # for merge queue
   merge_group:


### PR DESCRIPTION
While this would be great, the build check is required, thus we cannot skip it. Let's disable the condition as a quick workaround for now.