### PR TITLE
HMS-3276: Add support for building AMIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /output
 /bin
+__pycache__

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -66,6 +66,7 @@ def build_image(build_container, output_path, image_type):
         "--privileged",
         "--security-opt", "label=type:unconfined_t",
         "-v", f"{output_path}:/output",
+        "-v", "/store",  # share the cache between builds
         build_container,
         "quay.io/centos-bootc/fedora-bootc:eln",
         "--config", "/output/config.json",

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -149,8 +149,9 @@ def has_selinux():
 
 
 @pytest.mark.skipif(not has_selinux(), reason="selinux not enabled")
-def test_image_build_without_se_linux_denials(build_image):
-    # the journal always contains logs from the image building
-    assert build_image.journal_output != ""
-    assert not log_has_osbuild_selinux_denials(build_image.journal_output), \
-        f"denials in log {build_image.journal_output}"
+def test_image_build_without_se_linux_denials(build_image_qcow2, build_image_ami):
+    for build_image in [build_image_qcow2, build_image_ami]:
+        # the journal always contains logs from the image building
+        assert build_image.journal_output != ""
+        assert not log_has_osbuild_selinux_denials(build_image.journal_output), \
+            f"denials in log {build_image.journal_output}"


### PR DESCRIPTION
Add support for building an AMI with a `--type` flag.  The only difference between the qcow2 and the AMI is the output file format, which for AMI is raw.

The default image type is qcow2.

Tests now build and boot both image types.