### PR TITLE
Make the initial output of the command nicer

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -162,15 +162,16 @@ func build(cmd *cobra.Command, args []string) {
 
 	seedArg := int64(0)
 
-	fmt.Printf("Generating manifest for %s: ", config.Name)
+	manifest_fname := fmt.Sprintf("manifest-%s.json", imgType)
+	fmt.Printf("Generating %s ... ", manifest_fname)
 	mf, err := makeManifest(imgref, imgType, &config, repos, hostArch, seedArg, rpmCacheRoot)
 	check(err)
 	fmt.Print("DONE\n")
 
-	manifestPath := filepath.Join(outputDir, "manifest.json")
+	manifestPath := filepath.Join(outputDir, manifest_fname)
 	check(saveManifest(mf, manifestPath))
 
-	fmt.Printf("Building manifest: %s\n", manifestPath)
+	fmt.Printf("Building %s\n", manifest_fname)
 
 	_, err = osbuild.RunOSBuild(mf, osbuildStore, outputDir, exports, nil, nil, false, os.Stderr)
 	check(err)

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -188,6 +189,7 @@ func main() {
 		Run:                   build,
 	}
 
+	logrus.SetLevel(logrus.ErrorLevel)
 	rootCmd.Flags().String("output", ".", "artifact output directory")
 	rootCmd.Flags().String("store", ".osbuild", "osbuild store for intermediate pipeline trees")
 	rootCmd.Flags().String("rpmmd", "/var/cache/osbuild/rpmmd", "rpm metadata cache directory")

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/osbuild/images v0.24.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 )
 
@@ -69,7 +70,6 @@ require (
 	github.com/sigstore/fulcio v1.4.3 // indirect
 	github.com/sigstore/rekor v1.2.2 // indirect
 	github.com/sigstore/sigstore v1.7.5 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect


### PR DESCRIPTION
Before

```
$ podman run --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v $(pwd)/output:/output quay.io/centos-bootc/bootc-image-builder:latest quay.io/centos-bootc/fedora-bootc:eln --type ami
Generating manifest for empty: WARN[0000] Failed to load consumer certs: no consumer key found
DONE
Building manifest: /output/manifest.json
```

After

```
$ podman run --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v $(pwd)/output:/output quay.io/centos-bootc/bootc-image-builder:latest quay.io/centos-bootc/fedora-bootc:eln --type ami
Generating manifest-ami.json ... DONE
Building manifest-ami.json
```