### PR TITLE
Fix artifact ownership problems

### DIFF
--- a/bib/cmd/bootc-image-builder/export_test.go
+++ b/bib/cmd/bootc-image-builder/export_test.go
@@ -1,0 +1,11 @@
+package main
+
+var CanChownInPath = canChownInPath
+
+func MockOsGetuid(new func() int) (restore func()) {
+	saved := osGetuid
+	osGetuid = new
+	return func() {
+		osGetuid = saved
+	}
+}

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -43,6 +43,11 @@ type BuildConfig struct {
 	Blueprint *blueprint.Blueprint `json:"blueprint,omitempty"`
 }
 
+var (
+	osGetuid = os.Getuid
+	osGetgid = os.Getgid
+)
+
 // canChownInPath checks if the ownership of files can be set in a given path.
 func canChownInPath(path string) (bool, error) {
 	info, err := os.Stat(path)
@@ -63,7 +68,7 @@ func canChownInPath(path string) (bool, error) {
 			fmt.Fprintf(os.Stderr, "error deleting %s: %s\n", checkFile.Name(), err.Error())
 		}
 	}()
-	return checkFile.Chown(os.Getuid(), os.Getgid()) == nil, nil
+	return checkFile.Chown(osGetuid(), osGetgid()) == nil, nil
 }
 
 // Parse embedded repositories and return repo configs for the given

--- a/bib/cmd/bootc-image-builder/main_test.go
+++ b/bib/cmd/bootc-image-builder/main_test.go
@@ -1,0 +1,45 @@
+package main_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	main "github.com/osbuild/bootc-image-builder/bib/cmd/bootc-image-builder"
+)
+
+func TestCanChownInPathHappy(t *testing.T) {
+	tmpdir := t.TempDir()
+	canChown, err := main.CanChownInPath(tmpdir)
+	require.Nil(t, err)
+	assert.Equal(t, canChown, true)
+
+	// no tmpfile leftover
+	content, err := os.ReadDir(tmpdir)
+	require.Nil(t, err)
+	assert.Equal(t, len(content), 0)
+}
+
+func TestCanChownInPathNotExists(t *testing.T) {
+	canChown, err := main.CanChownInPath("/does/not/exists")
+	assert.Equal(t, canChown, false)
+	assert.ErrorContains(t, err, ": no such file or directory")
+}
+
+func TestCanChownInPathCannotChange(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("cannot run as root (fchown never errors here)")
+	}
+
+	restore := main.MockOsGetuid(func() int {
+		return -2
+	})
+	defer restore()
+
+	tmpdir := t.TempDir()
+	canChown, err := main.CanChownInPath(tmpdir)
+	require.Nil(t, err)
+	assert.Equal(t, canChown, false)
+}

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.8.4
 )
 
 require (
@@ -22,6 +23,7 @@ require (
 	github.com/containers/ocicrypt v1.1.9 // indirect
 	github.com/containers/storage v1.51.0 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v24.0.7+incompatible // indirect
@@ -67,6 +69,7 @@ require (
 	github.com/opencontainers/runc v1.1.10 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/proglottis/gpgme v0.1.3 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -270,6 +270,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
osbuild uses `cp -a` to export artifacts from a build and files are (usually) owned by root.  The `cp` command tries to set the ownership to root on the mounted volume from the host but if it's running in a podman machine, this will fail.

Added a new check, `canChownInPath()`, which creates a temporary file in the output directory and tries to `chown` it to the uid and gid of the caller.  This lets us know if osbuild will be able to preserve the permissions of the output file when copying the results, which should be created with the uid and gid of the caller of osbuild, to the output directory.

This is used to set export option when calling osbuild, `OSBUILD_EXPORT_FORCE_NO_PRESERVE_OWNER`.  The option prevents osbuild from trying to set the ownership of the files in the destination and failing.

Requires osbuild/osbuild#1511 or osbuild/osbuild#1512.

Output directory on macOS
```
$ ls -lR output
total 384
drwxr-xr-x  3 achilleas  staff     96 Dec 14 15:46 image
-rw-r--r--  1 achilleas  staff  95668 Dec 14 15:48 manifest-ami.json
-rw-r--r--  1 achilleas  staff  97855 Dec 14 15:57 manifest-qcow2.json
drwxr-xr-x  3 achilleas  staff     96 Dec 14 15:40 qcow2

output/image:
total 6496120
-rw-r--r--  1 achilleas  staff  10737418240 Dec 14 15:48 disk.raw

output/qcow2:
total 1278064
-rw-r--r--  1 achilleas  staff  640516096 Dec 14 15:58 disk.qcow2
```

Fixes #14 