### PR TITLE
Containerfile: Enable basic caching of go deps

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,7 @@
 FROM registry.fedoraproject.org/fedora:39 AS builder
-RUN dnf install -y git-core golang gpgme-devel libassuan-devel
-RUN mkdir /build
+RUN dnf install -y git-core golang gpgme-devel libassuan-devel && mkdir -p /build/bib
+COPY bib/go.mod bib/go.sum /build/bib
+RUN cd /build/bib && go mod download
 COPY build.sh /build
 COPY bib /build/bib
 WORKDIR /build


### PR DESCRIPTION
If we firstly copy go.mod and go.sum in and call go mod download, we get a cached layer with the go dependencies. This is useful for developers, because you only need to redownload the dependencies if go.mod or go.sum actually change.