### PR TITLE
Refactor, add --tls-verify and rework README

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -36,6 +36,9 @@ type ManifestConfig struct {
 
 	// CPU architecture of the image
 	Architecture arch.Arch
+
+	// TLSVerify specifies whether HTTPS and a valid TLS certificate are required
+	TLSVerify bool
 }
 
 func Manifest(c *ManifestConfig) (*manifest.Manifest, error) {
@@ -70,11 +73,10 @@ func pipelinesForDiskImage(c *ManifestConfig, rng *rand.Rand) (image.ImageKind, 
 		fail("pipeline: no base image defined")
 	}
 	ref := "ostree/1/1/0"
-	tlsVerify := true
 	containerSource := container.SourceSpec{
 		Source:    c.Imgref,
 		Name:      c.Imgref,
-		TLSVerify: &tlsVerify,
+		TLSVerify: &c.TLSVerify,
 	}
 
 	img := image.NewOSTreeDiskImageFromContainer(containerSource, ref)

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -40,10 +39,7 @@ func check(err error) {
 }
 
 type BuildConfig struct {
-	Name      string               `json:"name"`
-	OSTree    *ostree.ImageOptions `json:"ostree,omitempty"`
 	Blueprint *blueprint.Blueprint `json:"blueprint,omitempty"`
-	Depends   interface{}          `json:"depends,omitempty"` // ignored
 }
 
 // Parse embedded repositories and return repo configs for the given
@@ -144,9 +140,7 @@ func build(cmd *cobra.Command, args []string) {
 		fail(fmt.Sprintf("failed to create target directory: %s", err.Error()))
 	}
 
-	config := BuildConfig{
-		Name: "empty",
-	}
+	config := BuildConfig{}
 	if configFile != "" {
 		config = loadConfig(configFile)
 	}

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -135,6 +135,7 @@ func build(cmd *cobra.Command, args []string) {
 	rpmCacheRoot, _ := cmd.Flags().GetString("rpmmd")
 	configFile, _ := cmd.Flags().GetString("config")
 	imgType, _ := cmd.Flags().GetString("type")
+	tlsVerify, _ := cmd.Flags().GetBool("tls-verify")
 
 	if err := os.MkdirAll(outputDir, 0777); err != nil {
 		fail(fmt.Sprintf("failed to create target directory: %s", err.Error()))
@@ -163,6 +164,7 @@ func build(cmd *cobra.Command, args []string) {
 		Config:       &config,
 		Repos:        repos,
 		Architecture: hostArch,
+		TLSVerify:    tlsVerify,
 	}
 	mf, err := makeManifest(manifestConfig, rpmCacheRoot)
 	check(err)
@@ -194,5 +196,6 @@ func main() {
 	rootCmd.Flags().String("rpmmd", "/var/cache/osbuild/rpmmd", "rpm metadata cache directory")
 	rootCmd.Flags().String("config", "", "build config file")
 	rootCmd.Flags().String("type", "qcow2", "image type to build [qcow2, ami]")
+	rootCmd.Flags().Bool("tls-verify", true, "require HTTPS and verify certificates when contacting registries")
 	check(rootCmd.Execute())
 }

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -163,7 +163,6 @@ func build(cmd *cobra.Command, args []string) {
 		Config:       &config,
 		Repos:        repos,
 		Architecture: hostArch,
-		Seed:         int64(0),
 	}
 	mf, err := makeManifest(manifestConfig, rpmCacheRoot)
 	check(err)


### PR DESCRIPTION
This is unfortunately a bigger PR that I would have liked, but everything is sorta interconnected. 3 major things happening:

1) I created a new struct called `ManifestConfig` to hold everything needed to create a manifest. Adding new options with this struct is super-simple, and we also don't have functions accepting 6 arguments anymore.
2) I added a `--tls-verify` flag that allow disabling TLS verification. This is basically taken directly from `podman`.
3) I tweaked the README a bit. Arguments, image types and volumes are now tables. Customizations are now more properly documented. There are now emojis. I like them mostly because I think they add a lot of visual clarity where a section starts and where it ends.

You can see the tweaked readme here: https://github.com/ondrejbudai/osbuild-deploy-container/tree/insecure