### PR TITLE
cmd/bootc-image-builder: support to use aws credential file and profiles

### DIFF
--- a/bib/cmd/bootc-image-builder/cloud.go
+++ b/bib/cmd/bootc-image-builder/cloud.go
@@ -18,8 +18,12 @@ func uploadAMI(path string, flags *pflag.FlagSet) error {
 	if err != nil {
 		return err
 	}
+	awsProfile, err := flags.GetString("aws-profile")
+	if err != nil {
+		return err
+	}
 
-	client, err := uploader.NewAWSClient(region)
+	client, err := uploader.NewAWSClient(region, awsProfile)
 	if err != nil {
 		return err
 	}

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -136,6 +136,7 @@ func build(cmd *cobra.Command, args []string) {
 	configFile, _ := cmd.Flags().GetString("config")
 	imgType, _ := cmd.Flags().GetString("type")
 	tlsVerify, _ := cmd.Flags().GetBool("tls-verify")
+	awsProfile, _ := cmd.Flags().GetString("aws-profile")
 
 	if err := os.MkdirAll(outputDir, 0777); err != nil {
 		fail(fmt.Sprintf("failed to create target directory: %s", err.Error()))
@@ -144,10 +145,10 @@ func build(cmd *cobra.Command, args []string) {
 	upload := false
 	if region, _ := cmd.Flags().GetString("aws-region"); region != "" {
 		if imgType != "ami" {
-			fail("aws flags set for non-ami image type")
+			fail(fmt.Sprintf("aws flags set for non-ami image type (type is set to %s)", imgType))
 		}
 		// initialise the client to check if the env vars exist before building the image
-		_, err := uploader.NewAWSClient(region)
+		_, err := uploader.NewAWSClient(region, awsProfile)
 		check(err)
 		upload = true
 	}
@@ -223,6 +224,7 @@ func main() {
 	rootCmd.Flags().String("aws-region", "", "target region for AWS uploads (only for type=ami)")
 	rootCmd.Flags().String("aws-bucket", "", "target S3 bucket name for intermediate storage when creating AMI (only for type=ami)")
 	rootCmd.Flags().String("aws-ami-name", "", "name for the AMI in AWS (only for type=ami)")
+	rootCmd.Flags().String("aws-profile", "default", "credentials profile to use for uploading (only for type=ami)")
 
 	// flag rules
 	check(rootCmd.MarkFlagDirname("output"))


### PR DESCRIPTION
Support to use aws credential file and profiles
implements HMS-3305

please comment especially on the part with 
```
		// SMELL we might want to implement a separate function
		//  like awscloud.newFromLocalProfile(awsProfile string, region string)
```
		
i guess the function would look similar to this:
```
// Create a new session from the locally stored AWS credentials file
// but given profile. NewDefault() above will expect "default" as profile or use environment variable AWS_PROFILE
func newFromLocalProfile(profile string, region string) (*AWS, error) {
	// Create a Session with a custom region and specified profile
	sess, err := session.NewSessionWithOptions(session.Options{
		Config: aws.Config{
			Region: aws.String(region),
		},
		Profile: profile,
	})
	if err != nil {
		return nil, err
	}

	return &AWS{
		uploader: s3manager.NewUploader(sess),
		ec2:      ec2.New(sess),
		s3:       s3.New(sess),
	}, nil
}
```

but would need to go to the images repository...