### PR TITLE
A few minor patches

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -19,6 +19,9 @@ import (
 	"github.com/osbuild/images/pkg/runner"
 )
 
+// TODO: Auto-detect this from container image metadata
+const DEFAULT_SIZE = uint64(10 * GibiByte)
+
 type ManifestConfig struct {
 	// OCI image path (without the transport, that is always docker://)
 	Imgref string
@@ -140,8 +143,7 @@ func pipelinesForDiskImage(c *ManifestConfig, rng *rand.Rand) (image.ImageKind, 
 	if !ok {
 		fail(fmt.Sprintf("pipelines: no partition tables defined for %s", c.Architecture))
 	}
-	size := uint64(10 * GibiByte)
-	pt, err := disk.NewPartitionTable(&basept, nil, size, disk.RawPartitioningMode, nil, rng)
+	pt, err := disk.NewPartitionTable(&basept, nil, DEFAULT_SIZE, disk.RawPartitioningMode, nil, rng)
 	check(err)
 	img.PartitionTable = pt
 

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -95,6 +95,8 @@ func pipelinesForDiskImage(c *ManifestConfig, rng *rand.Rand) (image.ImageKind, 
 
 	img.KernelOptionsAppend = []string{
 		"rw",
+		// TODO: Drop this as we expect kargs to come from the container image,
+		// xref https://github.com/CentOS/centos-bootc-layered/blob/main/cloud/usr/lib/bootc/install/05-cloud-kargs.toml
 		"console=tty0",
 		"console=ttyS0",
 	}

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -111,16 +111,16 @@ func makeManifest(c *ManifestConfig, cacheRoot string) (manifest.OSBuildManifest
 func saveManifest(ms manifest.OSBuildManifest, fpath string) error {
 	b, err := json.MarshalIndent(ms, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal data for %q: %s\n", fpath, err.Error())
+		return fmt.Errorf("failed to marshal data for %q: %s", fpath, err.Error())
 	}
 	b = append(b, '\n') // add new line at end of file
 	fp, err := os.Create(fpath)
 	if err != nil {
-		return fmt.Errorf("failed to create output file %q: %s\n", fpath, err.Error())
+		return fmt.Errorf("failed to create output file %q: %s", fpath, err.Error())
 	}
 	defer fp.Close()
 	if _, err := fp.Write(b); err != nil {
-		return fmt.Errorf("failed to write output file %q: %s\n", fpath, err.Error())
+		return fmt.Errorf("failed to write output file %q: %s", fpath, err.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
image: Hoist up hardcoded constant, add TODO

To make it more obvious we should fix this.

---

Remove extraneous newlines from errors

My go linter correctly warns about these; the error
printer will include a newline as needed.

---

image: Add a TODO for kargs

This will go away when we use bootc.

---

