### PR TITLE
test: add `BIB_TEST_{BUILD,BOOTC}_CONTAINER_TAG` to customize tests

### DIFF
--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -26,6 +26,9 @@ if not testutil.has_x86_64_v3_cpu():
 @pytest.fixture(name="build_container", scope="session")
 def build_container_fixture():
     """Build a container from the Containerfile and returns the name"""
+    if tag_from_env := os.getenv("BIB_TEST_BUILD_CONTAINER_TAG"):
+        return tag_from_env
+
     container_tag = "bootc-image-builder-test"
     subprocess.check_call([
         "podman", "build",
@@ -52,6 +55,13 @@ def image_type_fixture(tmpdir_factory, build_container, request):
     Build an image inside the passed build_container and return an
     ImageBuildResult with the resulting image path and user/password
     """
+    # TODO: make this another indirect fixture input, e.g. by making
+    # making "image_type" an "image" tuple (type, container_ref_to_test)
+    container_to_build_ref = os.getenv(
+        "BIB_TEST_BOOTC_CONTAINER_TAG",
+        "quay.io/centos-bootc/fedora-bootc:eln",
+    )
+
     # image_type is passed via special pytest parameter fixture
     image_type = request.param
 
@@ -102,7 +112,7 @@ def image_type_fixture(tmpdir_factory, build_container, request):
         "-v", f"{output_path}:/output",
         "-v", "/store",  # share the cache between builds
         build_container,
-        "quay.io/centos-bootc/fedora-bootc:eln",
+        container_to_build_ref,
         "--config", "/output/config.json",
         "--type", image_type,
     ])


### PR DESCRIPTION
There is a desire to resue our tests to also test when new bootc containers are generated that they still build and boot. To do this we need a way to customize the tests further so that: a) we can omit building our code and instead use a "stable" container
   that contains bootc-image-builder
b) we can specificy what bootc (target) image to test so that the
   bootc building team can point to their staging area

This is currently done via environment variables. It might be worth exploring the pytest commandline option support [0] but that can be done in a followup.

[0] https://docs.pytest.org/en/7.1.x/example/simple.html