### PR TITLE
Boot test AMIs in AWS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Install test dependencies
       run: |
         sudo apt update
-        sudo apt install -y podman python3-pytest python3-paramiko flake8 qemu-system-x86
+        sudo apt install -y podman python3-pytest python3-paramiko python3-boto3 flake8 qemu-system-x86
     - name: Run tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -10,6 +10,7 @@ prepare:
   package:
     - podman
     - pytest
+    - python3-boto3
     - python3-flake8
     - python3-paramiko
     - qemu-kvm

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -16,4 +16,4 @@ prepare:
     - qemu-kvm
 execute:
   how: tmt
-  script: pytest -s -vv
+  script: pytest -s -vv --force-aws-upload

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--force-aws-upload", action="store_true", default=False,
+                     help=("Force AWS upload when building AMI, failing if credentials are not set. "
+                           "If not set, the upload will be performed only when credentials are available."))
+
+
+@pytest.fixture(name="force_aws_upload", scope="session")
+def force_aws_upload_fixture(request):
+    return request.config.getoption("--force-aws-upload")

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
 pytest==7.4.3
 flake8==6.1.0
 paramiko==2.12.0
+boto3==1.33.13

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -4,13 +4,15 @@ import pathlib
 import platform
 import re
 import subprocess
+import tempfile
+import uuid
 from typing import NamedTuple
 
 import pytest
 
 # local test utils
 import testutil
-from vm import QEMU
+from vm import AWS, QEMU
 
 if not testutil.has_executable("podman"):
     pytest.skip("no podman, skipping integration tests that required podman", allow_module_level=True)

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -10,7 +10,7 @@ import pytest
 
 # local test utils
 import testutil
-from vm import VM
+from vm import QEMU
 
 if not testutil.has_executable("podman"):
     pytest.skip("no podman, skipping integration tests that required podman", allow_module_level=True)
@@ -138,7 +138,7 @@ def test_image_is_generated(image_type):
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
 @pytest.mark.parametrize("image_type", SUPPORTED_IMAGE_TYPES, indirect=["image_type"])
 def test_image_boots(image_type):
-    with VM(image_type.img_path) as test_vm:
+    with QEMU(image_type.img_path) as test_vm:
         exit_status, _ = test_vm.run("true", user=image_type.username, password=image_type.password)
         assert exit_status == 0
         exit_status, output = test_vm.run("echo hello", user=image_type.username, password=image_type.password)

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -176,6 +176,16 @@ def test_image_boots(image_type):
         assert "hello" in output
 
 
+@pytest.mark.parametrize("image_type", ["ami"], indirect=["image_type"])
+def test_ami_boots_in_aws(image_type):
+    with AWS(image_type.metadata["ami_id"]) as test_vm:
+        exit_status, _ = test_vm.run("true", user=image_type.username, password=image_type.password)
+        assert exit_status == 0
+        exit_status, output = test_vm.run("echo hello", user=image_type.username, password=image_type.password)
+        assert exit_status == 0
+        assert "hello" in output
+
+
 def log_has_osbuild_selinux_denials(log):
     OSBUID_SELINUX_DENIALS_RE = re.compile(r"(?ms)avc:\ +denied.*osbuild")
     return re.search(OSBUID_SELINUX_DENIALS_RE, log)

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -86,11 +86,14 @@ def write_aws_creds(path):
     key_id = os.environ.get("AWS_ACCESS_KEY_ID")
     secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
     if not key_id or not secret_key:
-        raise RuntimeError("aws credentials not available")
+        return False
+
     with open(path, mode="w", encoding="utf-8") as creds_file:
         creds_file.write("[default]\n")
         creds_file.write(f"aws_access_key_id = {key_id}\n")
         creds_file.write(f"aws_secret_access_key = {secret_key}\n")
+
+    return True
 
 
 def deregister_ami(ami_id):

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -1,8 +1,8 @@
 import os
 import pathlib
 import platform
-import socket
 import shutil
+import socket
 import subprocess
 import time
 
@@ -37,12 +37,12 @@ def get_free_port() -> int:
         return s.getsockname()[1]
 
 
-def wait_ssh_ready(port, sleep, max_wait_sec):
+def wait_ssh_ready(address, port, sleep, max_wait_sec):
     for i in range(int(max_wait_sec / sleep)):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(sleep)
             try:
-                s.connect(("localhost", port))
+                s.connect((address, port))
                 data = s.recv(256)
                 if b"OpenSSH" in data:
                     return

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -6,6 +6,8 @@ import socket
 import subprocess
 import time
 
+AWS_REGION = "us-east-1"
+
 
 def run_journalctl(*args):
     pre = []

--- a/test/testutil_test.py
+++ b/test/testutil_test.py
@@ -5,7 +5,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from testutil import has_executable, get_free_port, wait_ssh_ready
+from testutil import get_free_port, has_executable, wait_ssh_ready
 
 
 def test_get_free_port():
@@ -21,7 +21,7 @@ def free_port_fixture():
 @patch("time.sleep")
 def test_wait_ssh_ready_sleeps_no_connection(mocked_sleep, free_port):
     with pytest.raises(ConnectionRefusedError):
-        wait_ssh_ready(free_port, sleep=0.1, max_wait_sec=0.35)
+        wait_ssh_ready("localhost", free_port, sleep=0.1, max_wait_sec=0.35)
     assert mocked_sleep.call_args_list == [call(0.1), call(0.1), call(0.1)]
 
 
@@ -45,7 +45,7 @@ def test_wait_ssh_ready_sleeps_wrong_reply(free_port, tmp_path):
         # now connect
         with patch("time.sleep") as mocked_sleep:
             with pytest.raises(ConnectionRefusedError):
-                wait_ssh_ready(free_port, sleep=0.1, max_wait_sec=0.55)
+                wait_ssh_ready("localhost", free_port, sleep=0.1, max_wait_sec=0.55)
             assert mocked_sleep.call_args_list == [
                 call(0.1), call(0.1), call(0.1), call(0.1), call(0.1)]
 
@@ -56,4 +56,4 @@ def test_wait_ssh_ready_integration(free_port, tmp_path):
     with contextlib.ExitStack() as cm:
         p = subprocess.Popen(f"echo OpenSSH | nc -l -p {free_port}", shell=True)
         cm.callback(p.kill)
-        wait_ssh_ready(free_port, sleep=0.1, max_wait_sec=10)
+        wait_ssh_ready("localhost", free_port, sleep=0.1, max_wait_sec=10)

--- a/test/vm.py
+++ b/test/vm.py
@@ -47,7 +47,7 @@ class VM(abc.ABC):
         self.start()
         return self
 
-    def __exit__(self, type, value, tb):
+    def __exit__(self, exc_type, exc_value, traceback):
         self.force_stop()
 
 

--- a/test/vm.py
+++ b/test/vm.py
@@ -1,33 +1,74 @@
+import abc
 import pathlib
 import subprocess
 import sys
 from io import StringIO
 
+from paramiko.client import AutoAddPolicy, SSHClient
+
 from testutil import get_free_port, wait_ssh_ready
 
 
-from paramiko.client import AutoAddPolicy, SSHClient
+class VM(abc.ABC):
+
+    def __init__(self):
+        self._ssh_port = None
+        self._address = None
+
+    def __del__(self):
+        self.force_stop()
+
+    @abc.abstractmethod
+    def start(self):
+        """
+        Start the VM. This method will be called automatically if it is not called explicitly before calling run().
+        """
+
+    def _log(self, msg):
+        # XXX: use a proper logger
+        sys.stdout.write(msg.rstrip("\n") + "\n")
+
+    def wait_ssh_ready(self):
+        wait_ssh_ready(self._address, self._ssh_port, sleep=1, max_wait_sec=600)
+
+    @abc.abstractmethod
+    def force_stop(self):
+        """
+        Stop the VM and clean up any resources that were created when setting up and starting the machine.
+        """
+
+    @abc.abstractmethod
+    def run(self, cmd, user, password):
+        """
+        Run a command on the VM via SSH using the provided credentials.
+        """
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, type, value, tb):
+        self.force_stop()
 
 
-class VM:
+class QEMU(VM):
+
     MEM = "2000"
     # TODO: support qemu-system-aarch64 too :)
     QEMU = "qemu-system-x86_64"
 
     def __init__(self, img, snapshot=True):
+        super().__init__()
         self._img = pathlib.Path(img)
         self._qemu_p = None
-        self._ssh_port = None
         self._snapshot = snapshot
-
-    def __del__(self):
-        self.force_stop()
 
     def start(self):
         if self._qemu_p is not None:
             return
         log_path = self._img.with_suffix(".serial-log")
         self._ssh_port = get_free_port()
+        self._address = "localhost"
         qemu_cmdline = [
             self.QEMU, "-enable-kvm",
             "-m", self.MEM,
@@ -51,24 +92,12 @@ class VM:
         self.wait_ssh_ready()
         self._log(f"vm ready at port {self._ssh_port}")
 
-    def _log(self, msg):
-        # XXX: use a proper logger
-        sys.stdout.write(msg.rstrip("\n") + "\n")
-
-    def wait_ssh_ready(self):
-        wait_ssh_ready(self._ssh_port, sleep=1, max_wait_sec=600)
-
     def force_stop(self):
         if self._qemu_p:
             self._qemu_p.kill()
             self._qemu_p = None
-
-    def __enter__(self):
-        self.start()
-        return self
-
-    def __exit__(self, type, value, tb):
-        self.force_stop()
+            self._address = None
+            self._ssh_port = None
 
     def run(self, cmd, user, password):
         if not self._qemu_p:
@@ -76,7 +105,7 @@ class VM:
         client = SSHClient()
         client.set_missing_host_key_policy(AutoAddPolicy)
         client.connect(
-            "localhost", self._ssh_port, user, password,
+            self._address, self._ssh_port, user, password,
             allow_agent=False, look_for_keys=False)
         chan = client.get_transport().open_session()
         chan.get_pty()

--- a/test/vm.py
+++ b/test/vm.py
@@ -163,7 +163,7 @@ class AWS(VM):
             self._ec2_instance.wait_until_running()
             self._ec2_instance.reload()  # make sure the instance info is up to date
             self._address = self._ec2_instance.public_ip_address
-            self._log("Instance is running")
+            self._log(f"Instance is running at {self._address}")
             self.wait_ssh_ready()
             self._log("SSH is ready")
         except ClientError as err:


### PR DESCRIPTION
When building a test AMI, upload it to AWS and boot it there, running the same smoke test as we do for the qcow2.
The local testing of the AMI is still run as before.

Added two subclasses to the VM class:
- QEMU: is the old code that initialises and boots an image in qemu.
- AWS: new code that launches (and terminates) an AMI.
