### PR TITLE
main: check credentials by listing regions HMS-3329

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -182,8 +182,13 @@ func build(cmd *cobra.Command, args []string) {
 			fail(fmt.Sprintf("aws flags set for non-ami image type (type is set to %s)", imgType))
 		}
 		// initialise the client to check if the env vars exist before building the image
-		_, err := awscloud.NewDefault(region)
+		client, err := awscloud.NewDefault(region)
 		check(err)
+
+		fmt.Printf("Checking AWS permission by listing regions...\n")
+		_, err = client.Regions()
+		check(err)
+
 		upload = true
 	}
 


### PR DESCRIPTION
Listing regions *early* in main.go is just a way to check if the credentials somehow work and fail/exit otherwise.

The upload is not guaranteed to work like this but might be a good indicator.