### PR TITLE
github: add AWS secrets to testing farm action

### DIFF
--- a/.github/workflows/testingfarm.yml
+++ b/.github/workflows/testingfarm.yml
@@ -56,3 +56,4 @@ jobs:
         git_ref: ${{ github.event.pull_request.head.ref }}
         pull_request_status_name: "Testing farm"
         tf_scope: private
+        secrets: "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}"


### PR DESCRIPTION
Add the AWS secrets to the testing farm action so we can run the AWS upload test in TF.

Opening this PR separately to get this into `main` for #93, since adding the change in the PR wont have an effect before it's merged.