### PR TITLE
bib: add "raw" image format

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -51,9 +51,7 @@ func Manifest(c *ManifestConfig) (*manifest.Manifest, error) {
 	var err error
 
 	switch c.ImgType {
-	case "qcow2":
-		fallthrough
-	case "ami":
+	case "ami", "qcow2", "raw":
 		img, err = pipelinesForDiskImage(c, rng)
 	case "iso":
 		img, err = pipelinesForISO(c, rng)
@@ -111,7 +109,7 @@ func pipelinesForDiskImage(c *ManifestConfig, rng *rand.Rand) (image.ImageKind, 
 	case "qcow2":
 		imageFormat = platform.FORMAT_QCOW2
 		filename = "disk.qcow2"
-	case "ami":
+	case "ami", "raw":
 		imageFormat = platform.FORMAT_RAW
 		filename = "disk.raw"
 	}

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -204,12 +204,12 @@ func build(cmd *cobra.Command, args []string) {
 	switch imgType {
 	case "qcow2":
 		exports = []string{"qcow2"}
-	case "ami":
+	case "ami", "raw":
 		exports = []string{"image"}
 	case "iso":
 		exports = []string{"bootiso"}
 	default:
-		fail(fmt.Sprintf("valid types are 'qcow2', 'ami', 'iso', not: '%s'", imgType))
+		fail(fmt.Sprintf("valid types are 'qcow2', 'ami', 'raw', 'iso', not: '%s'", imgType))
 	}
 
 	manifest_fname := fmt.Sprintf("manifest-%s.json", imgType)

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -42,7 +42,7 @@ def build_container_fixture():
 
 
 # image types to test
-SUPPORTED_IMAGE_TYPES = ["qcow2", "ami"]
+SUPPORTED_IMAGE_TYPES = ["qcow2", "ami", "raw"]
 
 
 class ImageBuildResult(NamedTuple):
@@ -80,6 +80,7 @@ def image_type_fixture(tmpdir_factory, build_container, request, force_aws_uploa
     artifact = {
         "qcow2": pathlib.Path(output_path) / "qcow2/disk.qcow2",
         "ami": pathlib.Path(output_path) / "image/disk.raw",
+        "raw": pathlib.Path(output_path) / "image/disk.raw",
     }
     assert len(artifact) == len(SUPPORTED_IMAGE_TYPES), \
         "please keep artifact mapping and supported images in sync"


### PR DESCRIPTION
A super simple PR to allow to get "raw" output for https://github.com/osbuild/bootc-image-builder/issues/99 

Right now this will be identical to an "ami" but it seems cleaner to me to me to separate the two as the may(?) diverge in the future.