### PR TITLE
ci: Ensure we `apt update` before `apt install`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
       uses: actions/setup-python@v5
     - name: Install test dependencies
       run: |
+        sudo apt update
         sudo apt install -y podman python3-pytest python3-paramiko flake8 qemu-system-x86
     - name: Run tests
       env:


### PR DESCRIPTION
Otherwise we can operate on cached metadata and fail.