### PR TITLE
bib: Add root filesystem selection (HMS-3110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Flags:
 | **--config** | Path to a [build config](#-build-config)                         |       ❌      |
 | --tls-verify | Require HTTPS and verify certificates when contacting registries |    `true`     |
 | **--type**   | [Image type](#-image-types) to build                             |    `qcow2`    |
+| --rootfs     | Root filesystem type to create. eg. ext4, xfs                    |    `ext4`     |
 
 *💡 Tip: Flags in **bold** are the most important ones.*
 

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -31,6 +31,11 @@ type ManifestConfig struct {
 	// TODO: Make this an enum.
 	ImgType string
 
+	// Root filesystem type (eg. ext4, xfs. empty defaults to ext4)
+	//
+	// TODO: Make this an enum driven by images/pkg/disk
+	RootFSType string
+
 	// Build config
 	Config *BuildConfig
 
@@ -141,7 +146,7 @@ func pipelinesForDiskImage(c *ManifestConfig, rng *rand.Rand) (image.ImageKind, 
 
 	img.Workload = &NullWorkload{}
 
-	basept, ok := partitionTables[c.Architecture.String()]
+	basept, ok := partitionTables(c.RootFSType)[c.Architecture.String()]
 	if !ok {
 		fail(fmt.Sprintf("pipelines: no partition tables defined for %s", c.Architecture))
 	}

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -169,6 +169,7 @@ func build(cmd *cobra.Command, args []string) {
 	rpmCacheRoot, _ := cmd.Flags().GetString("rpmmd")
 	configFile, _ := cmd.Flags().GetString("config")
 	imgType, _ := cmd.Flags().GetString("type")
+	rootFSType, _ := cmd.Flags().GetString("rootfs")
 	tlsVerify, _ := cmd.Flags().GetBool("tls-verify")
 
 	if err := os.MkdirAll(outputDir, 0777); err != nil {
@@ -209,6 +210,7 @@ func build(cmd *cobra.Command, args []string) {
 	manifestConfig := &ManifestConfig{
 		Imgref:       imgref,
 		ImgType:      imgType,
+		RootFSType:   rootFSType,
 		Config:       &config,
 		Repos:        repos,
 		Architecture: hostArch,
@@ -267,6 +269,7 @@ func main() {
 	buildCmd.Flags().String("rpmmd", "/var/cache/osbuild/rpmmd", "rpm metadata cache directory")
 	buildCmd.Flags().String("config", "", "build config file")
 	buildCmd.Flags().String("type", "qcow2", "image type to build [qcow2, ami]")
+	buildCmd.Flags().String("rootfs", "ext4", "Root filesystem type [ext4, xfs]")
 	buildCmd.Flags().Bool("tls-verify", true, "require HTTPS and verify certificates when contacting registries")
 	buildCmd.Flags().String("aws-region", "", "target region for AWS uploads (only for type=ami)")
 	buildCmd.Flags().String("aws-bucket", "", "target S3 bucket name for intermediate storage when creating AMI (only for type=ami)")

--- a/bib/cmd/bootc-image-builder/partition_tables.go
+++ b/bib/cmd/bootc-image-builder/partition_tables.go
@@ -11,101 +11,108 @@ const (
 	GibiByte = 1024 * 1024 * 1024 // GiB
 )
 
-var partitionTables = distro.BasePartitionTableMap{
-	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
-		Partitions: []disk.Partition{
-			{
-				Size:     1 * MebiByte,
-				Bootable: true,
-				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
-			},
-			{
-				Size: 501 * MebiByte,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "umask=0077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
+// partitionTables returns a map, indexed by arch string
+// The root filesystem type is set to rootFSType
+func partitionTables(rootFSType string) distro.BasePartitionTableMap {
+	if rootFSType == "" {
+		rootFSType = "ext4"
+	}
+	return distro.BasePartitionTableMap{
+		arch.ARCH_X86_64.String(): disk.PartitionTable{
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: "gpt",
+			Partitions: []disk.Partition{
+				{
+					Size:     1 * MebiByte,
+					Bootable: true,
+					Type:     disk.BIOSBootPartitionGUID,
+					UUID:     disk.BIOSBootPartitionUUID,
 				},
-			},
-			{
-				Size: 1 * GibiByte,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    1,
-					FSTabPassNo:  2,
+				{
+					Size: 501 * MebiByte,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						Label:        "EFI-SYSTEM",
+						FSTabOptions: "umask=0077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
 				},
-			},
-			{
-				Size: 2 * GibiByte,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: "defaults",
-					FSTabFreq:    1,
-					FSTabPassNo:  1,
+				{
+					Size: 1 * GibiByte,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.FilesystemDataUUID,
+					Payload: &disk.Filesystem{
+						Type:         "ext4",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    1,
+						FSTabPassNo:  2,
+					},
 				},
-			},
-		},
-	},
-	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID: "0xc1748067",
-		Type: "dos",
-		Partitions: []disk.Partition{
-			{
-				Size:     501 * MebiByte,
-				Type:     "06",
-				Bootable: true,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "umask=0077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Size: 1 * GibiByte,
-				Type: "83",
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    1,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Size: 2569 * MebiByte,
-				Type: "83",
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: "defaults",
-					FSTabFreq:    1,
-					FSTabPassNo:  1,
+				{
+					Size: 2 * GibiByte,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.RootPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         rootFSType,
+						Label:        "root",
+						Mountpoint:   "/",
+						FSTabOptions: "defaults",
+						FSTabFreq:    1,
+						FSTabPassNo:  1,
+					},
 				},
 			},
 		},
-	},
+		arch.ARCH_AARCH64.String(): disk.PartitionTable{
+			UUID: "0xc1748067",
+			Type: "dos",
+			Partitions: []disk.Partition{
+				{
+					Size:     501 * MebiByte,
+					Type:     "06",
+					Bootable: true,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						Label:        "EFI-SYSTEM",
+						FSTabOptions: "umask=0077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
+				},
+				{
+					Size: 1 * GibiByte,
+					Type: "83",
+					Payload: &disk.Filesystem{
+						Type:         "ext4",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    1,
+						FSTabPassNo:  2,
+					},
+				},
+				{
+					Size: 2569 * MebiByte,
+					Type: "83",
+					Payload: &disk.Filesystem{
+						Type:         rootFSType,
+						Label:        "root",
+						Mountpoint:   "/",
+						FSTabOptions: "defaults",
+						FSTabFreq:    1,
+						FSTabPassNo:  1,
+					},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
Add `--rootfs` to select the root filesystem type (eg. ext4, xfs). It defaults to ext4.