### PR TITLE
test: add container installer test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,8 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
+        # make sure test deps are available for root
+        sudo -E pip install --user -r test/requirements.txt
         # podman needs (parts of) the environment but will break when
         # XDG_RUNTIME_DIR is set.
         # TODO: figure out what exactly podman needs

--- a/bib/cmd/bootc-image-builder/fedora-eln.json
+++ b/bib/cmd/bootc-image-builder/fedora-eln.json
@@ -1,11 +1,11 @@
 {
   "aarch64": [
     {
-      "baseurl": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/aarch64/os/",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/eln/eln-aarch64-baseos-20240115/",
       "name": "baseos"
     },
     {
-      "baseurl": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/aarch64/os/",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/eln/eln-aarch64-appstream-20240115/",
       "name": "appstream"
     },
     {
@@ -43,11 +43,11 @@
   ],
   "x86_64": [
     {
-      "baseurl": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/x86_64/os/",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/eln/eln-x86_64-baseos-20240115/",
       "name": "baseos"
     },
     {
-      "baseurl": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/x86_64/os/",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/eln/eln-x86_64-appstream-20240115/",
       "name": "appstream"
     },
     {

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,3 +2,4 @@ pytest==7.4.3
 flake8==6.1.0
 paramiko==2.12.0
 boto3==1.33.13
+qmp==1.1.0

--- a/test/vm.py
+++ b/test/vm.py
@@ -120,13 +120,14 @@ class QEMU(VM):
             "-m", self.MEM,
             # get "illegal instruction" inside the VM otherwise
             "-cpu", "host",
-            "-nographic",
             "-serial", "stdio",
             "-monitor", "none",
             "-netdev", f"user,id=net.0,hostfwd=tcp::{self._ssh_port}-:22",
             "-device", "rtl8139,netdev=net.0",
             "-qmp", f"unix:{self._qmp_socket},server,nowait",
         ]
+        if not os.environ.get("OSBUILD_TEST_QEMU_GUI"):
+            qemu_cmdline.append("-nographic")
         if use_ovmf:
             qemu_cmdline.extend(["-bios", find_ovmf()])
         if self._cdrom:


### PR DESCRIPTION
Add a new integration test that checks that the container installer
is working. The contaner installer just does an unattended install
of a disk. The test will run qemu with the installer.iso and an
empty disk. Once a reboot from the ISO is detected (via QMP) qemu
exists and boots the test disk and checks that it boots and the
test user can login.
