### PR TITLE
bib/image: set the product name for the ISO

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -172,6 +172,9 @@ func pipelinesForISO(c *ManifestConfig, rng *rand.Rand) (image.ImageKind, error)
 	img := image.NewAnacondaContainerInstaller(containerSource, "")
 	img.SquashfsCompression = "zstd"
 
+	// TODO: Parametrize me!
+	img.Product = "Fedora"
+
 	img.ExtraBasePackages = rpmmd.PackageSet{
 		Include: []string{
 			"aajohan-comfortaa-fonts",


### PR DESCRIPTION
Anaconda uses the product name in the buildstamp when calling efibootmgr when setting up the bootloader for containers without bootupd.

Without the product name, the bootloader setup just crashed. This was manually verified using ghcr.io/ublue-os/silverblue-main:39.

See
https://github.com/rhinstaller/anaconda/blob/a8c654b406d128e0e423f4f892511374cc5258f7/pyanaconda/modules/storage/bootloader/efi.py#L88

Closes #114 