### PR TITLE
Hook up blueprint filesystem customizations

### DIFF
--- a/bib/cmd/bootc-image-builder/export_test.go
+++ b/bib/cmd/bootc-image-builder/export_test.go
@@ -1,6 +1,10 @@
 package main
 
-var CanChownInPath = canChownInPath
+var (
+	CanChownInPath                = canChownInPath
+	ApplyFilesystemCustomizations = applyFilesystemCustomizations
+	GetDistroAndRunner            = getDistroAndRunner
+)
 
 func MockOsGetuid(new func() int) (restore func()) {
 	saved := osGetuid

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -20,6 +20,7 @@ import (
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/policies"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
 	"github.com/sirupsen/logrus"
@@ -119,6 +120,11 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 
 	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
 		img.KernelOptionsAppend = append(img.KernelOptionsAppend, kopts.Append)
+	}
+
+	// Check the filesystem customizations against the policy
+	if err := blueprint.CheckMountpointsPolicy(customizations.GetFilesystems(), policies.OstreeMountpointPolicies); err != nil {
+		return nil, err
 	}
 
 	basept, ok := partitionTables[c.Architecture.String()]

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -137,8 +137,12 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 		}
 		rootFS.Type = c.RootFSType
 	}
+	filesystems := customizations.GetFilesystems()
+	if len(filesystems) == 0 {
+		filesystems = c.Filesystems
+	}
 
-	pt, err := disk.NewPartitionTable(&basept, c.Filesystems, DEFAULT_SIZE, disk.RawPartitioningMode, nil, rng)
+	pt, err := disk.NewPartitionTable(&basept, filesystems, DEFAULT_SIZE, disk.RawPartitioningMode, nil, rng)
 	if err != nil {
 		return nil, err
 	}

--- a/bib/cmd/bootc-image-builder/image_test.go
+++ b/bib/cmd/bootc-image-builder/image_test.go
@@ -1,14 +1,16 @@
-package main
+package main_test
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/osbuild/bootc-image-builder/bib/internal/source"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/runner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	bib "github.com/osbuild/bootc-image-builder/bib/cmd/bootc-image-builder"
+	"github.com/osbuild/bootc-image-builder/bib/internal/source"
 )
 
 func TestGetDistroAndRunner(t *testing.T) {
@@ -42,7 +44,7 @@ func TestGetDistroAndRunner(t *testing.T) {
 				ID:        c.id,
 				VersionID: c.versionID,
 			}
-			distro, runner, err := getDistroAndRunner(osRelease)
+			distro, runner, err := bib.GetDistroAndRunner(osRelease)
 			if c.expectedErr != "" {
 				assert.ErrorContains(t, err, c.expectedErr)
 			} else {

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -222,10 +222,6 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
                     "mountpoint": "/",
                     "minsize": "12GiB"
                 },
-                {
-                    "mountpoint": "/var/log",
-                    "minsize": "1GiB"
-                },
             ],
             "kernel": {
                 "append": kargs,
@@ -381,13 +377,13 @@ def test_image_boots(image_type):
         # XXX: read the fully yaml instead?
         assert f"image: {image_type.container_ref}" in output
 
-        # Figure out how big / is and make sure it is > 10GiB
+        # Figure out how big / is and make sure it is > 11bGiB
         # Note that df output is in 1k blocks, not bytes
         for line in output.splitlines():
             fields = line.split()
             if fields[0] == "/sysroot":
                 size = int(fields[1])
-                assert size > 10 * 1024 * 1024
+                assert size > 11 * 1024 * 1024
                 break
 
 


### PR DESCRIPTION
Really simple change :) The testing feels a bit klunky, suggestions welcome. I thought about checking the manifest, but it boots the image anyway so checking the output of `df` seemed to be the most straight forward way.
