### PR TITLE
build: Use tags to trim down containers/storage dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 set -euo pipefail
+# Keep this in sync with e.g. https://github.com/containers/podman/blob/2981262215f563461d449b9841741339f4d9a894/Makefile#L51
+# It turns off the esoteric containers-storage backends that add dependencies
+# on things like btrfs that we don't need.
+CONTAINERS_STORAGE_THIN_TAGS="containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay"
 
 cd bib
-go build -o ../bin/bootc-image-builder ./cmd/bootc-image-builder
+set -x
+go build -tags "${CONTAINERS_STORAGE_THIN_TAGS}" -o ../bin/bootc-image-builder ./cmd/bootc-image-builder


### PR DESCRIPTION
The default depends on btrfs, etc. that we don't need because ultimately we're just forking off skopeo anyways.