### PR TITLE
 Use C9S

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
-FROM registry.fedoraproject.org/fedora:39 AS builder
-RUN dnf install -y git-core golang gpgme-devel libassuan-devel && mkdir -p /build/bib
+FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
+RUN dnf install -y git-core golang && mkdir -p /build/bib
 COPY bib/go.mod bib/go.sum /build/bib
 RUN cd /build/bib && go mod download
 COPY build.sh /build
@@ -7,13 +7,9 @@ COPY bib /build/bib
 WORKDIR /build
 RUN ./build.sh
 
-FROM registry.fedoraproject.org/fedora:39
-# Install newer osbuild to fix the loop bug, see
-# - https://github.com/osbuild/bootc-image-builder/issues/7
-# - https://github.com/osbuild/bootc-image-builder/issues/9
-# - https://github.com/osbuild/osbuild/pull/1468
-COPY ./group_osbuild-osbuild-fedora-39.repo /etc/yum.repos.d/
-RUN dnf install -y osbuild osbuild-ostree osbuild-depsolve-dnf && dnf clean all
+FROM quay.io/centos/centos:stream9
+# FROM registry.access.redhat.com/ubi9/ubi:latest
+RUN dnf install -y osbuild osbuild-ostree  && dnf clean all
 COPY --from=builder /build/bin/bootc-image-builder /usr/bin/bootc-image-builder
 COPY entrypoint.sh /
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 set -euo pipefail
+# Keep this in sync with e.g. https://github.com/containers/podman/blob/2981262215f563461d449b9841741339f4d9a894/Makefile#L51
+# It turns off the esoteric containers-storage backends that add dependencies
+# on things like btrfs that we don't need.
+CONTAINERS_STORAGE_THIN_TAGS="containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay"
 
 cd bib
-go build -o ../bin/bootc-image-builder ./cmd/bootc-image-builder
+set -x
+go build -tags "${CONTAINERS_STORAGE_THIN_TAGS}" -o ../bin/bootc-image-builder ./cmd/bootc-image-builder


### PR DESCRIPTION


This is currently broken however because `osbuild-depsolve-dnf`
appears to be missing from the yum repositories...probably
because it needs to be added to the giant bizarre JSON file
in https://gitlab.com/redhat/centos-stream/release-engineering/pungi-centos/-/blob/centos-9-stream/prepopulate.json?ref_type=heads