### PR TITLE
bib: add experimental cross arch image building

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Install test dependencies
       run: |
         sudo apt update
-        sudo apt install -y podman python3-pytest python3-paramiko python3-boto3 flake8 qemu-system-x86
+        sudo apt install -y podman python3-pytest python3-paramiko python3-boto3 flake8 qemu-system-x86 qemu-efi-aarch64 qemu-system-arm qemu-user-static
     - name: Diskspace (before)
       run: |
         df -h

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -12,6 +12,7 @@ provision:
 prepare:
   how: install
   package:
+    - edk2-aarch64
     - podman
     - pytest
     - python3-boto3
@@ -19,6 +20,8 @@ prepare:
     - python3-paramiko
     - python3-pip
     - qemu-kvm
+    - qemu-system-aarch64
+    - qemu-user-static
 execute:
   how: tmt
   script: |

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -32,6 +32,7 @@ if platform.system() == "Linux" and platform.machine() == "x86_64" and not testu
 class ImageBuildResult(NamedTuple):
     img_type: str
     img_path: str
+    img_arch: str
     username: str
     password: str
     journal_output: str
@@ -51,7 +52,13 @@ def image_type_fixture(shared_tmpdir, build_container, request, force_aws_upload
     ImageBuildResult with the resulting image path and user/password
     """
     # image_type is passed via special pytest parameter fixture
-    container_ref, image_type = request.param.split(",")
+    if request.param.count(",") == 2:
+        container_ref, image_type, target_arch = request.param.split(",")
+    elif request.param.count(",") == 1:
+        container_ref, image_type = request.param.split(",")
+        target_arch = None
+    else:
+        raise ValueError(f"cannot parse {request.param.count}")
 
     username = "test"
     password = "password"
@@ -74,7 +81,7 @@ def image_type_fixture(shared_tmpdir, build_container, request, force_aws_upload
     if generated_img.exists():
         print(f"NOTE: reusing cached image {generated_img}")
         journal_output = journal_log_path.read_text(encoding="utf8")
-        yield ImageBuildResult(image_type, generated_img, username, password, journal_output)
+        yield ImageBuildResult(image_type, generated_img, target_arch, username, password, journal_output)
         return
 
     # no image yet, build it
@@ -99,6 +106,9 @@ def image_type_fixture(shared_tmpdir, build_container, request, force_aws_upload
 
     upload_args = []
     creds_args = []
+    target_arch_args = []
+    if target_arch:
+        target_arch_args = ["--target-arch", target_arch]
 
     with tempfile.TemporaryDirectory() as tempdir:
         if image_type == "ami":
@@ -129,6 +139,7 @@ def image_type_fixture(shared_tmpdir, build_container, request, force_aws_upload
             "--config", "/output/config.json",
             "--type", image_type,
             *upload_args,
+            *target_arch_args,
         ])
     journal_output = testutil.journal_after_cursor(cursor)
     metadata = {}
@@ -141,7 +152,7 @@ def image_type_fixture(shared_tmpdir, build_container, request, force_aws_upload
 
     journal_log_path.write_text(journal_output, encoding="utf8")
 
-    yield ImageBuildResult(image_type, generated_img, username, password, journal_output, metadata)
+    yield ImageBuildResult(image_type, generated_img, target_arch, username, password, journal_output, metadata)
     # Try to cache as much as possible
     disk_usage = shutil.disk_usage(generated_img)
     print(f"NOTE: disk usage after {generated_img}: {disk_usage.free / 1_000_000} / {disk_usage.total / 1_000_000}")
@@ -167,7 +178,7 @@ def test_image_is_generated(image_type):
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
 @pytest.mark.parametrize("image_type", gen_testcases("direct-boot"), indirect=["image_type"])
 def test_image_boots(image_type):
-    with QEMU(image_type.img_path) as test_vm:
+    with QEMU(image_type.img_path, arch=image_type.img_arch) as test_vm:
         exit_status, _ = test_vm.run("true", user=image_type.username, password=image_type.password)
         assert exit_status == 0
         exit_status, output = test_vm.run("echo hello", user=image_type.username, password=image_type.password)

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -1,3 +1,4 @@
+import platform
 import os
 
 
@@ -43,6 +44,14 @@ def gen_testcases(what):
             CONTAINERS_TO_TEST["centos"] + "," + DIRECT_BOOT_IMAGE_TYPES[2],
             CONTAINERS_TO_TEST["fedora"] + "," + DIRECT_BOOT_IMAGE_TYPES[0],
         ]
+        # do a cross arch test too
+        if platform.machine() == "x86_64":
+            # todo: add fedora:eln
+            test_cases.append(
+                f'{CONTAINERS_TO_TEST["centos"]},raw,arm64')
+        elif platform.machine() == "arm64":
+            # TODO: add arm64->x86_64 cross build test too
+            pass
         return test_cases
     elif what == "all":
         test_cases = []


### PR DESCRIPTION
[This is based on https://github.com/osbuild/bootc-image-builder/pull/138 and only the last two commits are relevant]

This draft PR outlines how we could do cross architecture image building. I.e. you `bootc-image-builder` on a mac and target an `amd64` machine.

The usage would be:
```
sudo podman run ... \
  --type qcow2 \
  --target-arch amd64 \
     quay.io/centos-bootc/fedora-bootc:eln
```
and this is predicated on the idea that the target container is available for both host and target architecture. When that is the case the container for the host architecture is used as a buildroot, the container for the target architecture is the target tree. Note that some stages chroot into the target tree so `qemu-user` is essential for this to work so that target achitecture code can be run transparently (because only very small amounts of code need to run emulated this is pretty fast still).