### PR TITLE
README: Added prerequisites section to AWS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ The following image types are currently available via the `--type` argument:
 
 ### Amazon Machine Images (AMIs)
 
+#### Prerequisites
+
+In order to successfully import an AMI into your AWS account, you need to have the [vmimport service role](https://docs.aws.amazon.com/vm-import/latest/userguide/required-permissions.html) configured on your account.
+
+#### Flags
+
 AMIs can be automatically uploaded to AWS by specifying the following flags:
 
 | Argument       | Description                                                      |


### PR DESCRIPTION
I had issues with the instructions when attempting the process on a brand new AWS account for testing. This will solve https://github.com/osbuild/bootc-image-builder/issues/127