### PR TITLE
many: unbreak integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,4 +112,4 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
-        pytest -rs -s -vv
+        pytest -rs -s -vv --basetemp="${TMPDIR}/tmp"

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -2,6 +2,10 @@ summary: Run all tests inside a VM environment
 provision:
   how: virtual
   image: fedora:39
+  # 120 means 120GB, disk has to be specificed here, the format from:
+  #   https://tmt.readthedocs.io/en/stable/spec/hardware.html#disk
+  # does not work here or below under "hardware"
+  disk: 120
   hardware:
     virtualization:
       is-supported: true
@@ -17,3 +21,6 @@ prepare:
 execute:
   how: tmt
   script: pytest -s -vv --force-aws-upload
+finish:
+  how: shell
+  script: df -h

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+# do not use /tmp by default as it may be on a tempfs and our tests can
+# generate 10G images (that full of holes so not really 10G but still)
+addopts = --basetemp=/var/tmp

--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -24,5 +24,9 @@ def container_to_build_ref():
     # making "image_type" an "image" tuple (type, container_ref_to_test)
     return os.getenv(
         "BIB_TEST_BOOTC_CONTAINER_TAG",
-        "quay.io/centos-bootc/fedora-bootc:eln",
+        # using this tag instead of ":eln" until
+        #  https://github.com/CentOS/centos-bootc/issues/184 and
+        #  https://github.com/osbuild/bootc-image-builder/issues/149
+        # are fixed
+        "quay.io/centos-bootc/fedora-bootc:ed19452a30c50900be0b78db5f68d9826cc14a2e402f752535716cffd92b4445",
     )


### PR DESCRIPTION
See the individual commits, this PR fixes three things:
1. asks tmt for more diskspace in general
2. move default /tmp for pytest to /var/tmp so that we do not suffer from tmpfs smallness
3. move to last known good quay.io/centos-bootc/fedora-bootc container before issues https://github.com/CentOS/centos-bootc/issues/184 and https://github.com/osbuild/bootc-image-builder/issues/149

This unblocks "main" but we still need to find a proper solution for (3)

--- 

The tests are currently running out of disk space inside the testing-farm environment. This commit should help debug this by adding `df -h` output after the test is run.

It also asks for 200GB disk space (which is probably way more than we need). Note that the docs say that the size is 250GB by default for things running inside the RH ranch so this might be redunant [1].

[1] https://docs.testing-farm.io/Testing%20Farm/0.1/test-request.html#hardware