### PR TITLE
main: `SilenceUsage: true` by default

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -299,6 +299,7 @@ func run() error {
 		Args:                  cobra.ExactArgs(1),
 		DisableFlagsInUseLine: true,
 		RunE:                  cmdBuild,
+		SilenceUsage:          true,
 	}
 	rootCmd.AddCommand(buildCmd)
 	manifestCmd := &cobra.Command{
@@ -307,6 +308,7 @@ func run() error {
 		Args:                  cobra.ExactArgs(1),
 		DisableFlagsInUseLine: true,
 		RunE:                  cmdManifest,
+		SilenceUsage:          true,
 	}
 	rootCmd.AddCommand(manifestCmd)
 	manifestCmd.Flags().String("rpmmd", "/var/cache/osbuild/rpmmd", "rpm metadata cache directory")


### PR DESCRIPTION
This pairs with usage of `RunE`, xref
https://github.com/osbuild/bootc-image-builder/commit/38ce0dacfcc997312710cacf351b95b9ea0c76b6