### PR TITLE
Rename `iso` -> `anaconda-iso`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The following image types are currently available via the `--type` argument:
 |-----------------------|---------------------------------------------------------------------------------------|
 | `ami`                 | [Amazon Machine Image](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) |
 | `qcow2` **(default)** | [QEMU](https://www.qemu.org/)                                                         |
-| `iso`                 | An unattended Anaconda installer that installs to the first disk found.               |
+| `anaconda-iso`        | An unattended Anaconda installer that installs to the first disk found.               |
 
 ## ☁️ Cloud uploaders
 

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -50,7 +50,7 @@ func Manifest(c *ManifestConfig) (*manifest.Manifest, error) {
 	switch c.ImgType {
 	case "ami", "qcow2", "raw":
 		return manifestForDiskImage(c, rng)
-	case "iso":
+	case "anaconda-iso", "iso":
 		return manifestForISO(c, rng)
 	default:
 		return nil, fmt.Errorf("Manifest(): unsupported image type %q", c.ImgType)

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -271,10 +271,10 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		exports = []string{"qcow2"}
 	case "ami", "raw":
 		exports = []string{"image"}
-	case "iso":
+	case "anaconda-iso", "iso":
 		exports = []string{"bootiso"}
 	default:
-		return fmt.Errorf("valid types are 'qcow2', 'ami', 'raw', 'iso', not: '%s'", imgType)
+		return fmt.Errorf("valid types are 'qcow2', 'ami', 'raw', 'anaconda-iso', not: '%s'", imgType)
 	}
 
 	manifestPath := filepath.Join(outputDir, manifest_fname)

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -75,7 +75,7 @@ def image_type_fixture(shared_tmpdir, build_container, request, force_aws_upload
         "qcow2": pathlib.Path(output_path) / "qcow2/disk.qcow2",
         "ami": pathlib.Path(output_path) / "image/disk.raw",
         "raw": pathlib.Path(output_path) / "image/disk.raw",
-        "iso": pathlib.Path(output_path) / "bootiso/install.iso",
+        "anaconda-iso": pathlib.Path(output_path) / "bootiso/install.iso",
     }
     assert len(artifact) == len(set(t.split(",")[1] for t in gen_testcases("all"))), \
         "please keep artifact mapping and supported images in sync"
@@ -248,7 +248,7 @@ def test_image_build_without_se_linux_denials(image_type):
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
-@pytest.mark.parametrize("image_type", gen_testcases("iso"), indirect=["image_type"])
+@pytest.mark.parametrize("image_type", gen_testcases("anaconda-iso"), indirect=["image_type"])
 def test_iso_installs(image_type):
     installer_iso_path = image_type.img_path
     test_disk_path = installer_iso_path.with_name("test-disk.img")

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -6,7 +6,7 @@ def gen_testcases(what):
     # supported images that can be directly booted
     DIRECT_BOOT_IMAGE_TYPES = ("qcow2", "ami", "raw")
     # supported images that require an install
-    INSTALLER_IMAGE_TYPES = ("iso",)
+    INSTALLER_IMAGE_TYPES = ("anaconda-iso",)
 
     # bootc containers that are tested by default
     CONTAINERS_TO_TEST = {
@@ -26,7 +26,7 @@ def gen_testcases(what):
         return CONTAINERS_TO_TEST.values()
     elif what == "ami-boot":
         return [cnt + ",ami" for cnt in CONTAINERS_TO_TEST.values()]
-    elif what == "iso":
+    elif what == "anaconda-iso":
         test_cases = []
         # only fedora right now, centos iso installer is broken right now:
         # https://github.com/osbuild/bootc-image-builder/issues/157


### PR DESCRIPTION
This PR just renames the `iso` artifact to `anaconda-iso`.

The reason is that I would like to potentially introduce a *different* generic "live iso" that generates *exactly the input container* just as a Live ISO, very similar to how Fedora CoreOS (and one of its parents, the original Container Linux) do it.

This (proposed) `live-iso` would have several use cases, such as always running from a PXE boot.  I also think this is the long term architecture for an ISO, as opposed to the current Anaconda.  It would also be the same as how e.g. Fedora Workstation does it, where the installer is just an app in the system.

Anyways again, this is just a rename.  For compatibility we continue to honor the `iso` as an alias.