### PR TITLE
github: switch to GH macos m1 runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,10 +87,7 @@ jobs:
 
   integration-macos:
     name: "Integration macos"
-    # disabled GH runner as it takes ~50min to run this test, self-hosted
-    # is much faster (~15min)
-    #runs-on: macos-13  # needed to get latest cpu
-    runs-on: self-hosted
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Now that GH provides M1 macOS runners we should use them :) See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/