### PR TITLE
github: fix golintci typecheck errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.2
+          version: v1.55.2
           args: --timeout 5m0s
           working-directory: bib
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
 
       # This is needed for the container upload dependencies
       - name: Install libgpgme devel package
-        run: sudo apt install -y libgpgme-dev
+        run: sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
We have a bunch of false positive test failures like:
```
Check failure on line 4 in bib/cmd/bootc-image-builder/partition_tables.go
GitHub Actions / ⌨ Lint

"github.com/osbuild/images/pkg/arch" imported and not used (typecheck)
```

It turns out this happens when golang-ci cannot compile the code. And that happened because the (indirect) imports from the container libraries need libbtrfs-dev and libdevmapper-dev to compile.