### PR TITLE
Add Containerfile for building from osbuild and images sources for development

### DIFF
--- a/devel/Containerfile
+++ b/devel/Containerfile
@@ -1,0 +1,35 @@
+FROM registry.fedoraproject.org/fedora:39 AS osbuild-builder
+# build osbuild RPMs
+RUN dnf install -y rpm-build dnf-plugins-core git-core
+COPY --from=osbuild . /build
+WORKDIR /build
+RUN dnf builddep -y osbuild.spec
+RUN git config --global --add safe.directory /build
+RUN make rpm
+
+
+FROM registry.fedoraproject.org/fedora:39 AS bib-builder
+# replace osbuild/images dependency and build bib
+RUN dnf install -y git-core golang gpgme-devel libassuan-devel
+COPY --from=images . /build/images
+COPY bib /build/bib
+COPY build.sh /build
+
+WORKDIR /build/bib
+RUN go mod edit -replace github.com/osbuild/images=../images
+RUN go mod tidy
+WORKDIR /build
+RUN ./build.sh
+
+
+FROM registry.fedoraproject.org/fedora:39
+RUN dnf install -y podman qemu-img
+COPY --from=osbuild-builder /build/rpmbuild/RPMS/noarch/*.rpm /rpms/
+RUN dnf install -y /rpms/*.rpm
+COPY --from=bib-builder /build/bin/bootc-image-builder /usr/bin/bootc-image-builder
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+VOLUME /output
+VOLUME /store
+VOLUME /rpmmd

--- a/devel/README.md
+++ b/devel/README.md
@@ -1,0 +1,19 @@
+# Developer guide and tooling
+
+The Containerfile contained in this directory is intended to help with working on the multiple components that make up bootc-image-builder. Its purpose is to simplify building the bootc-image-builder container from locally checked out, development versions of the following projects:
+1. [osbuild/osbuild](https://github.com/osbuild/osbuild)
+2. [osbuild/images](https://github.com/osbuild/images)
+3. [osbuild/bootc-image-builder](https://github.com/osbuild/bootc-image-builder) (this repository)
+
+The Containerfile expects two extra build contexts, one for each external component, pointing to the root of the source directory of each project. For example, given the following:
+```
+$ ls -1 ~/src
+images/
+osbuild/
+```
+the container can be built using:
+```
+$ podman build --file=devel/Containerfile --build-context=osbuild=$HOME/src/osbuild --build-context=images=$HOME/src/images -t bootc-image-builder:devel .
+```
+
+**NOTE**: The osbuild RPM build will fail if there are uncommitted changes in the repository.


### PR DESCRIPTION
New Containerfile that requires build contexts pointing to checked out sources for osbuild/osbuild and osbuild/images to make building development versions of all the components more convenient.

PR includes a README describing how to build the container.