### PR TITLE
Add selinux-policy-targeted and distribution-gpg-keys

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,7 +13,8 @@ FROM registry.fedoraproject.org/fedora:39
 # - https://github.com/osbuild/bootc-image-builder/issues/9
 # - https://github.com/osbuild/osbuild/pull/1468
 COPY ./group_osbuild-osbuild-fedora-39.repo /etc/yum.repos.d/
-RUN dnf install -y osbuild osbuild-ostree osbuild-depsolve-dnf podman qemu-img && dnf clean all
+COPY ./package-requires.txt .
+RUN grep -vE '^#' package-requires.txt | xargs dnf install -y && rm -f package-requires.txt && dnf clean all
 COPY --from=builder /build/bin/bootc-image-builder /usr/bin/bootc-image-builder
 COPY entrypoint.sh /
 

--- a/package-requires.txt
+++ b/package-requires.txt
@@ -1,0 +1,14 @@
+# List package dependencies here; this file is processed
+# from the Containerfile by default, using leading '#' as comments.
+
+# This project uses osbuild
+osbuild osbuild-ostree osbuild-depsolve-dnf
+
+# We mount container images internally
+podman
+
+# Image building dependencies
+qemu-img
+
+# rpm-ostree wants these for packages
+selinux-policy-targeted distribution-gpg-keys


### PR DESCRIPTION
This is part of reusing the bib container to build base images; rpm-ostree wants to have *a* policy to bootstrap from currently.

For distribution-gpg-keys, it allows `.repo` files to reference those unconditionally.

Also, reuse a "make package lists declarative" model I've used in other places.  It'd be nice to try to semi-standardize this of course, or even better upstream it into dnf.

We're looking at adding a different Containerfile in https://github.com/osbuild/bootc-image-builder/pull/174 and this way it can source the same requirements.