### PR TITLE
test: cache images when possible 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,10 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y podman python3-pytest python3-paramiko python3-boto3 flake8 qemu-system-x86
+    - name: Diskspace (before)
+      run: |
+        df -h
+        sudo du -sh * /var/tmp /tmp /var/lib/containers | sort -sh
     - name: Run tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -84,6 +88,11 @@ jobs:
         # XDG_RUNTIME_DIR is set.
         # TODO: figure out what exactly podman needs
         sudo -E XDG_RUNTIME_DIR= pytest-3 -s -vv
+    - name: Diskspace (after)
+      if: ${{ failure() }}
+      run: |
+        df -h
+        sudo du -sh * /var/tmp /tmp /var/lib/containers | sort -sh
 
   integration-macos:
     name: "Integration macos"

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -17,10 +17,14 @@ prepare:
     - python3-boto3
     - python3-flake8
     - python3-paramiko
+    - python3-pip
     - qemu-kvm
 execute:
   how: tmt
-  script: pytest -s -vv --force-aws-upload
+  script: |
+    pip install --user -r test/requirements.txt
+    pytest -s -vv --force-aws-upload
+  duration: 2h
 finish:
   how: shell
   script: df -h

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 # do not use /tmp by default as it may be on a tempfs and our tests can
 # generate 10G images (that full of holes so not really 10G but still)
-addopts = --basetemp=/var/tmp
+addopts = --basetemp=/var/tmp/bib-tests

--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -17,12 +17,3 @@ def build_container_fixture():
         "-t", container_tag,
     ])
     return container_tag
-
-
-def container_to_build_ref():
-    # TODO: make this another indirect fixture input, e.g. by making
-    # making "image_type" an "image" tuple (type, container_ref_to_test)
-    return os.getenv(
-        "BIB_TEST_BOOTC_CONTAINER_TAG",
-        "quay.io/centos-bootc/fedora-bootc:eln",
-    )

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -63,11 +63,6 @@ def image_type_fixture(tmpdir_factory, build_container, request, force_aws_uploa
         "please keep artifact mapping and supported images in sync"
     generated_img = artifact[image_type]
 
-    # if the fixture already ran and generated an image, use that
-    if generated_img.exists():
-        journal_output = journal_log_path.read_text(encoding="utf8")
-        return ImageBuildResult(image_type, generated_img, username, password, journal_output)
-
     # no image yet, build it
     CFG = {
         "blueprint": {
@@ -132,7 +127,10 @@ def image_type_fixture(tmpdir_factory, build_container, request, force_aws_uploa
 
     journal_log_path.write_text(journal_output, encoding="utf8")
 
-    return ImageBuildResult(image_type, generated_img, username, password, journal_output, metadata)
+    yield ImageBuildResult(image_type, generated_img, username, password, journal_output, metadata)
+    generated_img.unlink()
+    subprocess.run(["podman", "rmi", container_ref], check=False)
+    return
 
 
 def test_container_builds(build_container):

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -9,13 +9,17 @@ import testutil
 if not testutil.has_executable("podman"):
     pytest.skip("no podman, skipping integration tests that required podman", allow_module_level=True)
 
-from containerbuild import build_container_fixture, container_to_build_ref  # noqa: F401
+from containerbuild import build_container_fixture  # noqa: F401
+from testcases import gen_testcases
 
 
-def test_manifest_smoke(build_container):
+@pytest.mark.parametrize("image_type", gen_testcases("manifest"))
+def test_manifest_smoke(build_container, image_type):
+    container_ref = image_type.split(",")[0]
+
     output = subprocess.check_output([
         "podman", "run", "--rm",
-        f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "{container_to_build_ref()}"]',
+        f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "{container_ref}"]',
         build_container,
     ])
     manifest = json.loads(output)

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -1,0 +1,53 @@
+import os
+
+
+def gen_testcases(what):
+    # supported images that can be directly booted
+    DIRECT_BOOT_IMAGE_TYPES = ("qcow2", "ami", "raw")
+    # supported images that require an install
+    INSTALLER_IMAGE_TYPES = ("iso",)
+
+    # bootc containers that are tested by default
+    CONTAINERS_TO_TEST = {
+        "fedora": "quay.io/centos-bootc/fedora-bootc:eln",
+        "centos": "quay.io/centos-bootc/centos-bootc:stream9",
+    }
+    # allow commandline override, this is used when testing
+    # custom images
+    if os.getenv("BIB_TEST_BOOTC_CONTAINER_TAG"):
+        # TODO: make this more elegant
+        CONTAINERS_TO_TEST = {
+            "centos": os.getenv("BIB_TEST_BOOTC_CONTAINER_TAG"),
+            "fedora": [],
+        }
+
+    if what == "manifest":
+        return CONTAINERS_TO_TEST.values()
+    elif what == "ami-boot":
+        return [cnt + ",ami" for cnt in CONTAINERS_TO_TEST.values()]
+    elif what == "iso":
+        test_cases = []
+        # only fedora right now, centos iso installer is broken right now:
+        # https://github.com/osbuild/bootc-image-builder/issues/157
+        cnt = CONTAINERS_TO_TEST["fedora"]
+        for img_type in INSTALLER_IMAGE_TYPES:
+            test_cases.append(f"{cnt},{img_type}")
+        return test_cases
+    elif what == "direct-boot":
+        # skip some raw/ami tests (they are identical right now) to
+        # avoid overlong test runs but revisit this later and maybe just
+        # do more in parallel?
+        test_cases = [
+            CONTAINERS_TO_TEST["centos"] + "," + DIRECT_BOOT_IMAGE_TYPES[0],
+            CONTAINERS_TO_TEST["fedora"] + "," + DIRECT_BOOT_IMAGE_TYPES[1],
+            CONTAINERS_TO_TEST["centos"] + "," + DIRECT_BOOT_IMAGE_TYPES[2],
+            CONTAINERS_TO_TEST["fedora"] + "," + DIRECT_BOOT_IMAGE_TYPES[0],
+        ]
+        return test_cases
+    elif what == "all":
+        test_cases = []
+        for cnt in CONTAINERS_TO_TEST.values():
+            for img_type in DIRECT_BOOT_IMAGE_TYPES + INSTALLER_IMAGE_TYPES:
+                test_cases.append(f"{cnt},{img_type}")
+        return test_cases
+    raise ValueError(f"unknown test-case type {what}")


### PR DESCRIPTION
Build on top of https://github.com/osbuild/bootc-image-builder/pull/148

This PR adds code to speed up the tests by re-using images as much as possible. Ideally it would always share but because GH runners have constraint diskspace it will cleanup when the free space falls below 1GB (a bit arbitrary but should be a reasonable heuristic).