### PR TITLE
Manifest generation unit tests

### DIFF
--- a/bib/cmd/bootc-image-builder/main_test.go
+++ b/bib/cmd/bootc-image-builder/main_test.go
@@ -222,8 +222,60 @@ func TestManifestSerialization(t *testing.T) {
 		},
 	}
 
+	baseConfig := getBaseConfig()
 	userConfig := getUserConfig()
 	testCases := map[string]manifestTestCase{
+		"ami-base": {
+			config:     baseConfig,
+			imageType:  "ami",
+			containers: diskContainers,
+			expStages: map[string][]string{
+				"build": {"org.osbuild.container-deploy"},
+				"ostree-deployment": {
+					"org.osbuild.ostree.deploy.container",
+				},
+			},
+			nexpStages: map[string][]string{
+				"build": {"org.osbuild.rpm"},
+				"ostree-deployment": {
+					"org.osbuild.users",
+				},
+			},
+		},
+		"raw-base": {
+			config:     baseConfig,
+			imageType:  "raw",
+			containers: diskContainers,
+			expStages: map[string][]string{
+				"build": {"org.osbuild.container-deploy"},
+				"ostree-deployment": {
+					"org.osbuild.ostree.deploy.container",
+				},
+			},
+			nexpStages: map[string][]string{
+				"build": {"org.osbuild.rpm"},
+				"ostree-deployment": {
+					"org.osbuild.users",
+				},
+			},
+		},
+		"qcow2-base": {
+			config:     baseConfig,
+			imageType:  "qcow2",
+			containers: diskContainers,
+			expStages: map[string][]string{
+				"build": {"org.osbuild.container-deploy"},
+				"ostree-deployment": {
+					"org.osbuild.ostree.deploy.container",
+				},
+			},
+			nexpStages: map[string][]string{
+				"build": {"org.osbuild.rpm"},
+				"ostree-deployment": {
+					"org.osbuild.users",
+				},
+			},
+		},
 		"ami-user": {
 			config:     userConfig,
 			imageType:  "ami",

--- a/bib/cmd/bootc-image-builder/main_test.go
+++ b/bib/cmd/bootc-image-builder/main_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -8,6 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	main "github.com/osbuild/bootc-image-builder/bib/cmd/bootc-image-builder"
+	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func TestCanChownInPathHappy(t *testing.T) {
@@ -42,4 +46,107 @@ func TestCanChownInPathCannotChange(t *testing.T) {
 	canChown, err := main.CanChownInPath(tmpdir)
 	require.Nil(t, err)
 	assert.Equal(t, canChown, false)
+}
+
+type manifestTestCase struct {
+	config     *main.ManifestConfig
+	imageType  string
+	packages   map[string][]rpmmd.PackageSpec
+	containers map[string][]container.Spec
+	err        error
+}
+
+func TestManifestGenerationEmptyConfig(t *testing.T) {
+	baseConfig := &main.ManifestConfig{Imgref: "testempty"}
+	testCases := map[string]manifestTestCase{
+		"ami-base": {
+			config:    baseConfig,
+			imageType: "ami",
+		},
+		"raw-base": {
+			config:    baseConfig,
+			imageType: "raw",
+		},
+		"qcow2-base": {
+			config:    baseConfig,
+			imageType: "qcow2",
+		},
+		"iso-base": {
+			config:    baseConfig,
+			imageType: "iso",
+		},
+		"empty-config": {
+			config:    &main.ManifestConfig{},
+			imageType: "qcow2",
+			err:       errors.New("pipeline: no base image defined"),
+		},
+		"bad-image-type": {
+			config:    baseConfig,
+			imageType: "bad",
+			err:       errors.New("Manifest(): unsupported image type \"bad\""),
+		},
+	}
+
+	assert := assert.New(t)
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			config := main.ManifestConfig(*tc.config)
+			config.ImgType = tc.imageType
+			_, err := main.Manifest(&config)
+			assert.Equal(err, tc.err)
+		})
+	}
+}
+
+func TestManifestGenerationUserConfig(t *testing.T) {
+	// add a user
+	pass := "super-secret-password-42"
+	key := "ssh-ed25519 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	userConfig := &main.ManifestConfig{
+		Imgref:  "testuser",
+		ImgType: "",
+		Config: &main.BuildConfig{
+			Blueprint: &blueprint.Blueprint{
+				Customizations: &blueprint.Customizations{
+					User: []blueprint.UserCustomization{
+						{
+							Name:     "tester",
+							Password: &pass,
+							Key:      &key,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := map[string]manifestTestCase{
+		"ami-user": {
+			config:    userConfig,
+			imageType: "ami",
+		},
+		"raw-user": {
+			config:    userConfig,
+			imageType: "raw",
+		},
+		"qcow2-user": {
+			config:    userConfig,
+			imageType: "qcow2",
+		},
+		"iso-user": {
+			config:    userConfig,
+			imageType: "iso",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			config := main.ManifestConfig(*tc.config)
+			config.ImgType = tc.imageType
+			_, err := main.Manifest(&config)
+
+			assert := assert.New(t)
+			assert.NoError(err)
+		})
+	}
 }


### PR DESCRIPTION
Adding some quick unit tests to check that:
- Manifest generation and serialization doesn't fail with valid configs.
- Manifest generation fails with expected errors with invalid configs.
- Manifest serialization fails with expected errors with invalid resolved sources.
- Serialized manifests contain expected stages.

These are quite basic and don't cover anything that wouldn't be caught by our more comprehensive integration tests, but are useful for catching regressions quickly (especially for rapid iteration during development).