### PR TITLE
Drain logic from entrypoint into Go code

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,6 +20,7 @@ COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]
 VOLUME /output
+WORKDIR /output
 VOLUME /store
 VOLUME /rpmmd
 

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -335,7 +335,7 @@ func run() error {
 		SilenceUsage:          true,
 	}
 	rootCmd.AddCommand(manifestCmd)
-	manifestCmd.Flags().String("rpmmd", "/var/cache/osbuild/rpmmd", "rpm metadata cache directory")
+	manifestCmd.Flags().String("rpmmd", "/rpmmd", "rpm metadata cache directory")
 	manifestCmd.Flags().String("config", "", "build config file")
 	manifestCmd.Flags().String("type", "qcow2", "image type to build [qcow2, ami]")
 	manifestCmd.Flags().Bool("tls-verify", true, "require HTTPS and verify certificates when contacting registries")
@@ -344,7 +344,7 @@ func run() error {
 	logrus.SetLevel(logrus.ErrorLevel)
 	buildCmd.Flags().AddFlagSet(manifestCmd.Flags())
 	buildCmd.Flags().String("output", ".", "artifact output directory")
-	buildCmd.Flags().String("store", ".osbuild", "osbuild store for intermediate pipeline trees")
+	buildCmd.Flags().String("store", "/store", "osbuild store for intermediate pipeline trees")
 	buildCmd.Flags().String("aws-region", "", "target region for AWS uploads (only for type=ami)")
 	buildCmd.Flags().String("aws-bucket", "", "target S3 bucket name for intermediate storage when creating AMI (only for type=ami)")
 	buildCmd.Flags().String("aws-ami-name", "", "name for the AMI in AWS (only for type=ami)")

--- a/devel/Containerfile
+++ b/devel/Containerfile
@@ -31,5 +31,6 @@ COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 VOLUME /output
+WORKDIR /output
 VOLUME /store
 VOLUME /rpmmd

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-/usr/bin/bootc-image-builder build --store /store --rpmmd /rpmmd --output /output "$@"
+# TODO: This script only exists for legacy reasons, the plan is to start requiring
+# a e.g. `build-image` entrypoint.
+/usr/bin/bootc-image-builder build "$@"


### PR DESCRIPTION
This is prep for adding multiple entrypoints; right now the Go code has a `build` verb that is always injected by this wrapper.

Move the default values into the Go code.

A future change will likely make things so that users are required to pass `build` (or perhaps `build-disk`) and this shell script goes away entirely.