### PR TITLE
Ensure root_t label for /store

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -237,7 +237,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	if err := setup.Validate(); err != nil {
 		return err
 	}
-	if err := setup.EnsureEnvironment(); err != nil {
+	if err := setup.EnsureEnvironment(osbuildStore); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The way osbuild works is to synthesize a filesystem tree in the store, then copy it to the disk.  This ensures the label for the store is `root_t` which ends up being the labeling for the "infrastructure" bits in the `/ostree` repository in the target root.

This in turn is blocking a lot of things.

Closes: https://github.com/osbuild/bootc-image-builder/issues/149