### PR TITLE
Mount /boot ro by default

### DIFF
--- a/bib/cmd/bootc-image-builder/partition_tables.go
+++ b/bib/cmd/bootc-image-builder/partition_tables.go
@@ -9,6 +9,11 @@ import (
 const (
 	MebiByte = 1024 * 1024        // MiB
 	GibiByte = 1024 * 1024 * 1024 // GiB
+	// BootOptions defines the mountpoint options for /boot
+	// See https://github.com/containers/bootc/pull/341 for the rationale for
+	// using `ro` by default.  Briefly it protects against corruption
+	// by non-ostree aware tools.
+	BootOptions = "ro"
 )
 
 var partitionTables = distro.BasePartitionTableMap{
@@ -44,7 +49,7 @@ var partitionTables = distro.BasePartitionTableMap{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
 					Label:        "boot",
-					FSTabOptions: "defaults",
+					FSTabOptions: BootOptions,
 					FSTabFreq:    1,
 					FSTabPassNo:  2,
 				},
@@ -89,7 +94,7 @@ var partitionTables = distro.BasePartitionTableMap{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
 					Label:        "boot",
-					FSTabOptions: "defaults",
+					FSTabOptions: BootOptions,
 					FSTabFreq:    1,
 					FSTabPassNo:  2,
 				},


### PR DESCRIPTION
See https://github.com/containers/bootc/pull/294
This is particularly motivated by https://github.com/CentOS/centos-bootc-dev/pull/27 because with that suddenly `dnf` will appear to start working but trying to do anything involving the kernel (i.e. mutating `/boot`) will end in sadness, and this puts a stop to that.

(This also relates of course to ye olde https://github.com/osbuild/bootc-image-builder/issues/18
 where we want the partitioning setup in the default case
 to come from the container)