### PR TITLE
bib: include fixed qemu for bib#207 and support using it

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,6 +13,17 @@ FROM registry.fedoraproject.org/fedora:39
 # - https://github.com/osbuild/bootc-image-builder/issues/9
 # - https://github.com/osbuild/osbuild/pull/1468
 COPY ./group_osbuild-osbuild-fedora-39.repo /etc/yum.repos.d/
+
+# XXX: remove once qemu is fixed in fedora,
+# see https://github.com/osbuild/bootc-image-builder/issues/207
+COPY ./michaelvogt-qemu-fix-bib-207-fedora-39.repo /etc/yum.repos.d/
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+       dnf install -y qemu-user-static-aarch64; \
+    elif [ "$(uname -m)" = "arm64" ]; then \
+       dnf install -y qemu-user-static-x86; \
+    fi
+# -----------------------------
+
 COPY ./package-requires.txt .
 RUN grep -vE '^#' package-requires.txt | xargs dnf install -y && rm -f package-requires.txt && dnf clean all
 COPY --from=builder /build/bin/bootc-image-builder /usr/bin/bootc-image-builder

--- a/bib/internal/setup/setup.go
+++ b/bib/internal/setup/setup.go
@@ -3,16 +3,60 @@ package setup
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/osbuild/bootc-image-builder/bib/internal/podmanutil"
 	"github.com/osbuild/bootc-image-builder/bib/internal/util"
 	"golang.org/x/sys/unix"
 )
 
+var binfmtMiscPath = "/proc/sys/fs/binfmt_misc"
+
+// XXX: binfmt_misc is not namespaced so this alters the host, see also
+// https://lore.kernel.org/all/20211028103114.2849140-2-brauner@kernel.org/
+var binFmtMiscHandlers = map[string]string{
+	"amd64": `:qemu-bib-aarch64:M::\x7f\x45\x4c\x46\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-aarch64-static:OCPF`,
+
+	"arm64": `:qemu-bib-x86_64:M::\x7f\x45\x4c\x46\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\xfc\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-x86_64-static:OCPF`,
+}
+
+func setupInternalQemu() error {
+	handler, ok := binFmtMiscHandlers[runtime.GOARCH]
+	if !ok {
+		return nil
+	}
+
+	if output, err := exec.Command("mount", "-t", "binfmt_misc", "none", binfmtMiscPath).CombinedOutput(); err != nil {
+		return fmt.Errorf("mounting binfmt misc failed: %v\noutput:\n%s", err, string(output))
+	}
+	// XXX: unregistering existing handlers can be done via writing a -1
+	// to existing ones and in theory the last one added wins so we could
+	// cleanup aftre the build is finished
+	f, err := os.OpenFile(filepath.Join(binfmtMiscPath, "register"), os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// binfmt-misc is global, so EEXIST is fine, it mean bib ran before
+	if _, err := f.WriteString(handler); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	return f.Close()
+}
+
 // EnsureEnvironment mutates external filesystem state as necessary
 // to run in a container environment.  This function is idempotent.
 func EnsureEnvironment() error {
+	if forceInternal := os.Getenv("BIB_FORCE_INTERNAL_QEMU"); forceInternal == "1" {
+		if err := setupInternalQemu(); err != nil {
+			return err
+		}
+	}
+
 	osbuildPath := "/usr/bin/osbuild"
 	if util.IsMountpoint(osbuildPath) {
 		return nil

--- a/michaelvogt-qemu-fix-bib-207-fedora-39.repo
+++ b/michaelvogt-qemu-fix-bib-207-fedora-39.repo
@@ -1,0 +1,10 @@
+[copr:copr.fedorainfracloud.org:michaelvogt:qemu-fix-bib-207]
+name=Copr repo for qemu-fix-bib-207 owned by michaelvogt
+baseurl=https://download.copr.fedorainfracloud.org/results/michaelvogt/qemu-fix-bib-207/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/michaelvogt/qemu-fix-bib-207/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -134,6 +134,8 @@ def image_type_fixture(shared_tmpdir, build_container, request, force_aws_upload
             "podman", "run", "--rm",
             "--privileged",
             "--security-opt", "label=type:unconfined_t",
+            # HACK
+            "-e", "BIB_FORCE_INTERNAL_QEMU=1",
             "-v", f"{output_path}:/output",
             "-v", "/store",  # share the cache between builds
             *creds_args,

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -43,6 +43,8 @@ def gen_testcases(what):
             CONTAINERS_TO_TEST["fedora"] + "," + DIRECT_BOOT_IMAGE_TYPES[1],
             CONTAINERS_TO_TEST["centos"] + "," + DIRECT_BOOT_IMAGE_TYPES[2],
             CONTAINERS_TO_TEST["fedora"] + "," + DIRECT_BOOT_IMAGE_TYPES[0],
+            # test for https://github.com/osbuild/bootc-image-builder/issues/207
+            "quay.io/rhel-edge/centos-bootc-test:v7vu,raw",
         ]
         # do a cross arch test too
         if platform.machine() == "x86_64":


### PR DESCRIPTION
This commit allows working around the issue described in https://github.com/osbuild/bootc-image-builder/issues/207

The workaround is that the container will register it's own binfmt-misc handler with the fixed `qemu-user` that got submitted in
https://lists.nongnu.org/archive/html/qemu-devel/2024-02/msg03971.html when the environment `BIB_FORCE_INTERNAL_QEMU=1` is set.

As this modifies the global state of the machine it's not something we want to do but might be a way to unblock people who need this functionatlity.

Fwiw, I tested that it successfully builds the image from #207:
```
$ sudo pytest-3 -s -vv './test/test_build.py::test_image_is_generated[quay.io/rhel-edge/centos-bootc-test:v7vu,raw]'
test/test_build.py::test_image_is_generated[quay.io/rhel-edge/centos-bootc-test:v7vu,raw] [1/2] STEP 1/8: FROM registry.fedoraproject.org/fedora:39 AS builder
...
  Duration: 2s
build:    	d6bf532cb83584bfc733f2ddbd042c29bcb0faf6d9e7919a1c12941fda3c01b3
ostree-deployment:	eb12d81faaf72350f7fadfd3a9869fb18bf19029fc0b38d0b95cada65e6457cd
image:    	f1dc28be4a8586c8bd25dfdeb5bdc0e19b7dcc9b9f007e51484be549002c2223
Build complete!
Results saved in
.
PASSED
=================== 1 passed, 1 warning in 462.99s (0:07:42) ===================
```

[edit: DO NOT MERGE, here for awareness what we could do]