### PR TITLE
bib: support uploading to `--target-arch` as well

### DIFF
--- a/bib/cmd/bootc-image-builder/cloud.go
+++ b/bib/cmd/bootc-image-builder/cloud.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func uploadAMI(path string, flags *pflag.FlagSet) error {
+func uploadAMI(path, targetArch string, flags *pflag.FlagSet) error {
 	region, err := flags.GetString("aws-region")
 	if err != nil {
 		return err
@@ -24,5 +24,5 @@ func uploadAMI(path string, flags *pflag.FlagSet) error {
 	if err != nil {
 		return err
 	}
-	return uploader.UploadAndRegister(client, path, bucketName, imageName)
+	return uploader.UploadAndRegister(client, path, bucketName, imageName, targetArch)
 }

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -232,6 +232,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	outputDir, _ := cmd.Flags().GetString("output")
 	osbuildStore, _ := cmd.Flags().GetString("store")
 	imgType, _ := cmd.Flags().GetString("type")
+	targetArch, _ := cmd.Flags().GetString("target-arch")
 
 	if err := setup.Validate(); err != nil {
 		return err
@@ -309,7 +310,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		switch imgType {
 		case "ami":
 			diskpath := filepath.Join(outputDir, exports[0], "disk.raw")
-			if err := uploadAMI(diskpath, cmd.Flags()); err != nil {
+			if err := uploadAMI(diskpath, targetArch, cmd.Flags()); err != nil {
 				return err
 			}
 		default:

--- a/bib/cmd/upload/main.go
+++ b/bib/cmd/upload/main.go
@@ -32,8 +32,10 @@ func uploadAMI(cmd *cobra.Command, args []string) {
 	check(err)
 	imageName, err := flags.GetString("ami-name")
 	check(err)
+	targetArch, err := flags.GetString("target-arch")
+	check(err)
 
-	check(uploader.UploadAndRegister(client, filename, bucketName, imageName))
+	check(uploader.UploadAndRegister(client, filename, bucketName, imageName, targetArch))
 }
 
 func setupCLI() *cobra.Command {

--- a/bib/internal/uploader/aws.go
+++ b/bib/internal/uploader/aws.go
@@ -11,7 +11,7 @@ import (
 	"github.com/osbuild/images/pkg/cloud/awscloud"
 )
 
-func UploadAndRegister(a *awscloud.AWS, filename, bucketName, imageName string) error {
+func UploadAndRegister(a *awscloud.AWS, filename, bucketName, imageName, targetArch string) error {
 	keyName := fmt.Sprintf("%s-%s", uuid.New().String(), filepath.Base(filename))
 
 	fmt.Printf("Uploading %s to %s:%s\n", filename, bucketName, keyName)
@@ -21,10 +21,12 @@ func UploadAndRegister(a *awscloud.AWS, filename, bucketName, imageName string) 
 	}
 	fmt.Printf("File uploaded to %s\n", aws.StringValue(&uploadOutput.Location))
 
-	hostArch := arch.Current()
+	if targetArch == "" {
+		targetArch = arch.Current().String()
+	}
 	bootMode := ec2.BootModeValuesUefiPreferred
 	fmt.Printf("Registering AMI %s\n", imageName)
-	ami, snapshot, err := a.Register(imageName, bucketName, keyName, nil, hostArch.String(), &bootMode)
+	ami, snapshot, err := a.Register(imageName, bucketName, keyName, nil, targetArch, &bootMode)
 	fmt.Printf("Deleted S3 object %s:%s\n", bucketName, keyName)
 	fmt.Printf("AMI registered: %s\nSnapshot ID: %s\n", aws.StringValue(ami), aws.StringValue(snapshot))
 	if err != nil {


### PR DESCRIPTION
There is a bug in the bib code right now that when uploading the AMI. It assume that the images are always build for the host architecture. But bib supports building/uploading cross-architecture images too.

Thanks to Ondrej for spotting this.

[this really should have a test but we need this urgently, I will try to write one after]