### PR TITLE
Add troubleshooting guide

### DIFF
--- a/devel/Troubleshooting.md
+++ b/devel/Troubleshooting.md
@@ -3,6 +3,7 @@
 If your container image fails to build using bootc-image-builder, or if it builds successfully but fails to boot, it's often not clear if the problem lies with bootc-image-builder or the container itself.
 
 To test building an image without bootc-image-builder, try the [bootc-install](devel/bootc-install) script in this repository.
+A more detailed guide for building a disk image using `bootc install` can be found [in the bootc docs](https://github.com/containers/bootc/blob/main/docs/install.md#executing-bootc-install)
 
 **IMPORTANT**
 Before running the script, note that it creates a file called `disk.raw` in the working directory. Make sure this action doesn't overwrite any existing files.

--- a/devel/Troubleshooting.md
+++ b/devel/Troubleshooting.md
@@ -1,0 +1,15 @@
+# Troubleshooting build failures
+
+If your container image fails to build using bootc-image-builder, or if it builds successfully but fails to boot, it's often not clear if the problem lies with bootc-image-builder or the container itself.
+
+To test building an image without bootc-image-builder, try the [bootc-install](devel/bootc-install) script in this repository.
+
+**IMPORTANT**
+Before running the script, note that it creates a file called `disk.raw` in the working directory. Make sure this action doesn't overwrite any existing files.
+
+After the disk is created, you can boot test it using qemu. It's best to convert it to a qcow2 image first:
+```
+qemu-img convert -O qcow disk.raw disk.qcow2
+```
+
+You can then follow the [instructions in the README](README.md#running-the-resulting-qcow2-file-on-linux-x86_64) to test that the image boots successfully.

--- a/devel/bootc-install
+++ b/devel/bootc-install
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# This is a minimal test script that installs the centos-bootc container to a
+# disk image without using bootc-image-builder. It's meant for investigating
+# build or boot issues when it's not clear if the source of the issue is BIB,
+# or something in the bootable container itself.
+
+set -euo pipefail
+
+container="$1"
+
+echo "Creating disk"
+truncate disk.raw --size 20G
+
+echo "Running bootc install"
+sudo podman run \
+    --rm \
+    -it \
+    --privileged \
+    --pull=newer \
+    --security-opt label=type:unconfined_t \
+    -v ./disk.raw:/disk.raw \
+    --pid=host \
+    "${container}" \
+    bootc install to-disk --via-loopback "/disk.raw"


### PR DESCRIPTION
Add a troubleshooting guide and a script that builds an image from a bootable container using `bootc install to-disk`, effectively removing BIB from the pipeline.  The guide and script are meant for investigating build or boot issues when it's not clear if the source of the issue is BIB, or something in the bootable container itself.

I'd like for the troubleshooting guide to be extended with more information about what users can try to investigate or work around failures.  We could also later link to https://gitlab.com/bootc-org/podman-bootc-cli with information on how to use it for debugging.

I initially considered linking to the guide from an issue template on GitHub but I think for now we can keep it here and link to it when we want more information from users reporting issues.

@cgwalters I tested the script with the current quay.io/centos-bootc/centos-bootc:stream9 (image ID `f1e476c5f5d61c0eb50f5d5e2e161595d29a8ebc500940d532e90c8fd483b5df`) and it worked but failed to boot with UEFI in qemu.  BIOS boot worked.

Is this something with the way I run the container?