### PR TITLE
Allow users to specify multiple types

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Flags:
 | **--tls-verify** | Require HTTPS and verify certificates when contacting registries |    `true`     |
 | **--type**       | [Image type](#-image-types) to build                             |    `qcow2`    |
 
+The `--type` parameter can be given multiple times and multiple outputs will
+be produced.
+
 *💡 Tip: Flags in **bold** are the most important ones.*
 
 ## 💾 Image types

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -297,7 +297,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("chowning is not allowed in output directory")
 	}
 
-	manifest_fname := fmt.Sprintf("manifest-%s.json", imgTypes[0])
+	manifest_fname := fmt.Sprintf("manifest-%s.json", strings.Join(imgTypes, "-"))
 	fmt.Printf("Generating %s ... ", manifest_fname)
 	mf, err := manifestFromCobra(cmd, args)
 	if err != nil {

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -187,6 +187,14 @@ func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, error) {
 	rpmCacheRoot, _ := cmd.Flags().GetString("rpmmd")
 	targetArch, _ := cmd.Flags().GetString("target-arch")
 	tlsVerify, _ := cmd.Flags().GetBool("tls-verify")
+
+	// translate anaconda-iso to iso to avoid multiple image type checks
+	for idx := range imgTypes {
+		if imgTypes[idx] == "anaconda-iso" {
+			imgTypes[idx] = "iso"
+		}
+	}
+
 	if targetArch != "" {
 		// TODO: detect if binfmt_misc for target arch is
 		// available, e.g. by mounting the binfmt_misc fs into

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -342,10 +342,10 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("Build complete!")
 	if upload {
-		for _, imgType := range imgTypes {
+		for idx, imgType := range imgTypes {
 			switch imgType {
 			case "ami":
-				diskpath := filepath.Join(outputDir, imgType, "disk.raw")
+				diskpath := filepath.Join(outputDir, exports[idx], "disk.raw")
 				if err := uploadAMI(diskpath, targetArch, cmd.Flags()); err != nil {
 					return err
 				}

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -222,10 +222,21 @@ func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, error) {
 		config = &BuildConfig{}
 	}
 
+	// Disk image types should all share mostly the same manifest but with
+	// different export pipelines.
+	// Right now the qcow2 contains all the pipelines required for ami and raw,
+	// so if one of the image types is qcow2, build that and export pipelines
+	// accordingly if needed.
+	// NOTE: THIS WILL CHANGE WITH THE INTRODUCTION OF NEW IMAGE TYPES
+	imgType := imgTypes[0]
+	if slices.Contains(imgTypes, "qcow2") {
+		imgType = "qcow2"
+	}
+
 	manifestConfig := &ManifestConfig{
 		Architecture: buildArch,
 		Config:       config,
-		ImgType:      imgTypes[0],
+		ImgType:      imgType,
 		Imgref:       imgref,
 		Repos:        repos,
 		TLSVerify:    tlsVerify,

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/sys v0.18.0
 )
 
@@ -104,7 +105,6 @@ require (
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 # do not use /tmp by default as it may be on a tempfs and our tests can
 # generate 10G images (that full of holes so not really 10G but still)
-addopts = --basetemp=/var/tmp/bib-tests
+addopts = --basetemp=/var/tmp/bib-tests --durations=0

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -137,12 +137,14 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
                 image_type, generated_img, target_arch, username, password,
                 bib_output, journal_output))
 
-    # Because we always build all image types, regardless of what was requested, we should either have 0 results or all
-    # should be available, so if we found at least one result but not all of them, this is a problem with our setup
-    assert not results or len(results) == len(image_types), \
-        f"unexpected number of results found: requested {image_types} but got {results}"
-
-    if results:
+    # return cached results only if we have exactly the amount of images
+    # requested. the reason is that for multi-images we cannot just return
+    # partial results. And because tests run in random order it maybe that
+    # a multi-image test runs after a single image test that already generated
+    # one of the types the multi images requested.
+    # TODO: rework the whole helper and extract the cache check and the build
+    # into their (tested) functions
+    if len(results) == len(image_types):
         yield results
         return
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -113,8 +113,20 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
     assert len(artifact) == len(set(t.split(",")[1] for t in gen_testcases("all"))), \
         "please keep artifact mapping and supported images in sync"
 
+    # this helper checks the cache
     results = []
     for image_type in image_types:
+        # TODO: properly cache amis here. The issue right now is that
+        # ami and raw are the same image on disk which means that if a test
+        # like "boots_in_aws" requests an ami it will get the raw file on
+        # disk. However that is not sufficient because part of the ami test
+        # is the upload to AWS and the generated metadata. The fix could be
+        # to make the boot-in-aws a new image type like "ami-aws" where we
+        # cache the metadata instead of the disk image. Alternatively we
+        # could stop testing ami locally at all and just skip any ami tests
+        # if there are no AWS credentials.
+        if image_type == "ami":
+            continue
         generated_img = artifact[image_type]
         print(f"Checking for cached image {image_type} -> {generated_img}")
         if generated_img.exists():

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -12,9 +12,10 @@ from containerbuild import build_container_fixture  # noqa: F401
 from testcases import gen_testcases
 
 
-@pytest.mark.parametrize("images", gen_testcases("manifest"))
-def test_manifest_smoke(build_container, images):
-    container_ref = images.split(",")[0]
+@pytest.mark.parametrize("testcase_ref", gen_testcases("manifest"))
+def test_manifest_smoke(build_container, testcase_ref):
+    # testcases_ref has the form "container_url,img_type1+img_type2,arch"
+    container_ref = testcase_ref.split(",")[0]
 
     output = subprocess.check_output([
         "podman", "run", "--rm",

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -5,7 +5,6 @@ import pytest
 
 import testutil
 
-
 if not testutil.has_executable("podman"):
     pytest.skip("no podman, skipping integration tests that required podman", allow_module_level=True)
 
@@ -13,9 +12,9 @@ from containerbuild import build_container_fixture  # noqa: F401
 from testcases import gen_testcases
 
 
-@pytest.mark.parametrize("image_type", gen_testcases("manifest"))
-def test_manifest_smoke(build_container, image_type):
-    container_ref = image_type.split(",")[0]
+@pytest.mark.parametrize("images", gen_testcases("manifest"))
+def test_manifest_smoke(build_container, images):
+    container_ref = images.split(",")[0]
 
     output = subprocess.check_output([
         "podman", "run", "--rm",

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -36,12 +36,13 @@ def gen_testcases(what):
             test_cases.append(f"{cnt},{img_type}")
         return test_cases
     elif what == "direct-boot":
-        # skip some raw/ami tests (they are identical right now) to
-        # avoid overlong test runs but revisit this later and maybe just
-        # do more in parallel?
+        # Do not do any AMI tests here, just test the raw image (which is
+        # identical to ami right now). The AMI needs to also get uploaded
+        # so they really need their own dedicated AMI test via the "ami-boot"
+        # test-cases
         test_cases = [
             CONTAINERS_TO_TEST["centos"] + "," + DIRECT_BOOT_IMAGE_TYPES[0],
-            CONTAINERS_TO_TEST["fedora"] + "," + DIRECT_BOOT_IMAGE_TYPES[1],
+            CONTAINERS_TO_TEST["fedora"] + "," + DIRECT_BOOT_IMAGE_TYPES[2],
             CONTAINERS_TO_TEST["centos"] + "," + DIRECT_BOOT_IMAGE_TYPES[2],
             CONTAINERS_TO_TEST["fedora"] + "," + DIRECT_BOOT_IMAGE_TYPES[0],
         ]

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -1,13 +1,14 @@
-import platform
 import os
+import platform
+
+# supported images that can be directly booted
+DIRECT_BOOT_IMAGE_TYPES = ("qcow2", "ami", "raw")
+
+# supported images that require an install
+INSTALLER_IMAGE_TYPES = ("anaconda-iso",)
 
 
 def gen_testcases(what):
-    # supported images that can be directly booted
-    DIRECT_BOOT_IMAGE_TYPES = ("qcow2", "ami", "raw")
-    # supported images that require an install
-    INSTALLER_IMAGE_TYPES = ("anaconda-iso",)
-
     # bootc containers that are tested by default
     CONTAINERS_TO_TEST = {
         "fedora": "quay.io/centos-bootc/fedora-bootc:eln",
@@ -58,5 +59,12 @@ def gen_testcases(what):
         for cnt in CONTAINERS_TO_TEST.values():
             for img_type in DIRECT_BOOT_IMAGE_TYPES + INSTALLER_IMAGE_TYPES:
                 test_cases.append(f"{cnt},{img_type}")
+        return test_cases
+    elif what == "multidisk":
+        # single test that specifies all image types
+        test_cases = []
+        for cnt in CONTAINERS_TO_TEST.values():
+            img_type = "+".join(DIRECT_BOOT_IMAGE_TYPES)
+            test_cases.append(f"{cnt},{img_type}")
         return test_cases
     raise ValueError(f"unknown test-case type {what}")


### PR DESCRIPTION
When producting a disk image, I want to be able to specify multiple at the same time. This would speed up builds and allow creating of an AMI, ISO and qcow2 all in one run.