### PR TITLE
test: disable anaconda-iso test because of issue#233

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -6,7 +6,9 @@ def gen_testcases(what):
     # supported images that can be directly booted
     DIRECT_BOOT_IMAGE_TYPES = ("qcow2", "ami", "raw")
     # supported images that require an install
-    INSTALLER_IMAGE_TYPES = ("anaconda-iso",)
+    # 2024-03-05: disabled because of https://github.com/osbuild/bootc-image-builder/issues/233
+    #INSTALLER_IMAGE_TYPES = ("anaconda-iso",)
+    INSTALLER_IMAGE_TYPES = []
 
     # bootc containers that are tested by default
     CONTAINERS_TO_TEST = {


### PR DESCRIPTION
This commit disabled the anaconda-install test that fails currently because of https://github.com/osbuild/bootc-image-builder/issues/233