### PR TITLE
bib: mount `devtmpfs` inside the container too

### DIFF
--- a/bib/internal/setup/setup.go
+++ b/bib/internal/setup/setup.go
@@ -53,6 +53,14 @@ func EnsureEnvironment() error {
 	if err := util.RunCmdSync("mount", "--bind", destPath, osbuildPath); err != nil {
 		return err
 	}
+
+	// Ensure we have devfs inside the container to get dynamic loop
+	// loop devices inside the container.
+	devMnt := "/dev/"
+	if err := util.RunCmdSync("mount", "-t", "devtmpfs", "devtmpfs", devMnt); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/bib/internal/setup/setup.go
+++ b/bib/internal/setup/setup.go
@@ -48,18 +48,19 @@ func EnsureEnvironment() error {
 	if err := util.RunCmdSync("chcon", installType, destPath); err != nil {
 		return err
 	}
+
+	// Ensure we have devfs inside the container to get dynamic loop
+	// loop devices inside the container.
+	if err := util.RunCmdSync("mount", "-t", "devtmpfs", "devtmpfs", "/dev"); err != nil {
+		return err
+	}
+
 	// Create a bind mount into our target location; we can't copy it because
 	// again we have to perserve the SELinux label.
 	if err := util.RunCmdSync("mount", "--bind", destPath, osbuildPath); err != nil {
 		return err
 	}
-
-	// Ensure we have devfs inside the container to get dynamic loop
-	// loop devices inside the container.
-	devMnt := "/dev/"
-	if err := util.RunCmdSync("mount", "-t", "devtmpfs", "devtmpfs", devMnt); err != nil {
-		return err
-	}
+	// NOTE: Don't add new code here, do it before the bind mount which acts as the final success indicator
 
 	return nil
 }


### PR DESCRIPTION
This ensures that the new `partscan` feature in osbuild works. By default the containers only have a static snapshot of /dev on a tmpfs. This means that anything later added by losetup will be missing inside the container.

It also means that https://github.com/osbuild/osbuild/pull/1468 can be reverted.

This should unblock https://github.com/osbuild/bootc-image-builder/pull/120 and also https://github.com/osbuild/images/pull/462