### PR TITLE
test: disable anaconda-iso test because of issue#233

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -247,6 +247,7 @@ def test_image_build_without_se_linux_denials(image_type):
         f"denials in log {image_type.journal_output}"
 
 
+@pytest.mark.skip(reason="see https://github.com/osbuild/bootc-image-builder/issues/233")
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
 @pytest.mark.parametrize("image_type", gen_testcases("anaconda-iso"), indirect=["image_type"])
 def test_iso_installs(image_type):


### PR DESCRIPTION
This commit disabled the anaconda-install test that fails currently because of https://github.com/osbuild/bootc-image-builder/issues/233

[resurrecting https://github.com/osbuild/bootc-image-builder/pull/234 as https://github.com/osbuild/bootc-image-builder/pull/231 seems to need more work]