### PR TITLE
devel: Add Makefile and Containerfile.hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+# There's no heavy lifting here; this file is just a convenience
+# for people whose muscle memory for building projects starts with typing `make`.
+all:
+	./build.sh

--- a/devel/Containerfile.hack
+++ b/devel/Containerfile.hack
@@ -1,0 +1,15 @@
+# This Containerfile is targeted to a specialized path where you are changing
+# pure Go code in this project and you're building on the host system with
+# a compatible userspace (e.g. c9s or fedora).  We just take the already
+# built binary and inject it on top of the main upstream container image.
+#
+# Crucially, using this flow imposes no constraints on your build setup,
+# so that adding e.g. `replace github.com/osbuild/images => ../images`
+# will Just Work.
+#
+# To use this, do e.g.:
+#
+# make && podman build --no-cache -t localhost/bib -v $(pwd)/bin:/srcbin -f devel/Containerfile.hack .
+#
+FROM quay.io/centos-bootc/bootc-image-builder:latest
+RUN install /srcbin/bootc-image-builder /usr/bin


### PR DESCRIPTION
Two conveniences:

- I commonly work on multiple projects in multiple languages and I find it very useful to have typing `make` do something useful by default.
- This `Containerfile.hack` I found is a lot faster and more understandable for the case of just wanting to hack on the Go code including changes to osbuild/images versus what is in `devel/Containerfile` which is much more heavyweight and assumes we're also hacking on osbuild.