### PR TITLE
test: add integration tests for new --chown feature

### DIFF
--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import textwrap
 
 import pytest
 
@@ -15,5 +16,37 @@ def build_container_fixture():
         "podman", "build",
         "-f", "Containerfile",
         "-t", container_tag,
+    ])
+    return container_tag
+
+
+@pytest.fixture(name="build_fake_container", scope="session")
+def build_fake_container_fixture(tmpdir_factory, build_container):
+    """Build a container with a fake osbuild and returns the name"""
+    tmp_path = tmpdir_factory.mktemp("build-fake-container")
+
+    fake_osbuild_path = tmp_path / "fake-osbuild"
+    fake_osbuild_path.write_text(textwrap.dedent("""\
+    #!/bin/sh -e
+
+    mkdir -p /output/qcow2
+    echo "fake-disk.qcow2" > /output/qcow2/disk.qcow2
+
+    echo "Done"
+    """), encoding="utf8")
+
+    cntf_path = tmp_path / "Containerfile"
+
+    cntf_path.write_text(textwrap.dedent(f"""\n
+    FROM {build_container}
+    COPY fake-osbuild /usr/bin/osbuild
+    RUN chmod 755 /usr/bin/osbuild
+    """), encoding="utf8")
+
+    container_tag = "bootc-image-builder-test-faked-osbuild"
+    subprocess.check_call([
+        "podman", "build",
+        "-t", container_tag,
+        tmp_path,
     ])
     return container_tag

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -1,0 +1,29 @@
+import subprocess
+
+import pytest
+
+from containerbuild import build_container_fixture, build_fake_container_fixture  # noqa: F401
+
+
+@pytest.mark.parametrize("chown_opt,expected_uid_gid", [
+    ([], (0, 0)),
+    (["--chown", "1000:1000"], (1000, 1000)),
+    (["--chown", "1000"], (1000, 0)),
+])
+def test_bib_chown_opts(tmp_path, build_fake_container, chown_opt, expected_uid_gid):
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+
+    subprocess.check_call([
+        "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
+        "-v", f"{output_path}:/output",
+        build_fake_container,
+        "quay.io/centos-bootc/centos-bootc:stream9",
+    ] + chown_opt)
+    expected_output_disk = output_path / "qcow2/disk.qcow2"
+    for p in output_path, expected_output_disk:
+        assert p.exists()
+        assert p.stat().st_uid == expected_uid_gid[0]
+        assert p.stat().st_gid == expected_uid_gid[1]


### PR DESCRIPTION
This also adds some infrastructure to fake the actual osbuild run which is potentially useful in the future as well.