### PR TITLE
test: add test that ensures "vmdk" images are build (HMS-3758)

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -170,14 +170,12 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
                 image_type, generated_img, target_arch, username, password,
                 bib_output, journal_output))
 
-    # return cached results only if we have exactly the amount of images
-    # requested. the reason is that for multi-images we cannot just return
-    # partial results. And because tests run in random order it maybe that
-    # a multi-image test runs after a single image test that already generated
-    # one of the types the multi images requested.
-    # TODO: rework the whole helper and extract the cache check and the build
-    # into their (tested) functions
-    if len(results) == len(image_types):
+    # Because we always build all image types, regardless of what was requested, we should either have 0 results or all
+    # should be available, so if we found at least one result but not all of them, this is a problem with our setup
+    assert not results or len(results) == len(image_types), \
+        f"unexpected number of results found: requested {image_types} but got {results}"
+
+    if results:
         yield results
         return
 

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -4,8 +4,8 @@ import platform
 # supported images that can be directly booted
 QEMU_BOOT_IMAGE_TYPES = ("qcow2", "raw")
 
-# images that can *not* be booted directly from qemu
-NON_QEMU_BOOT_IMAGE_TYPES = ("vmdk",)
+# supported images that can be booted in a cloud
+CLOUD_BOOT_IMAGE_TYPES = ("ami",)
 
 # images that can *not* be booted directly from qemu
 NON_QEMU_BOOT_IMAGE_TYPES = ("vmdk",)
@@ -58,7 +58,10 @@ def gen_testcases(what):
     elif what == "all":
         test_cases = []
         for cnt in CONTAINERS_TO_TEST.values():
-            for img_type in QEMU_BOOT_IMAGE_TYPES + NON_QEMU_BOOT_IMAGE_TYPES + INSTALLER_IMAGE_TYPES:
+            for img_type in QEMU_BOOT_IMAGE_TYPES + \
+                    CLOUD_BOOT_IMAGE_TYPES + \
+                    NON_QEMU_BOOT_IMAGE_TYPES + \
+                    INSTALLER_IMAGE_TYPES:
                 test_cases.append(f"{cnt},{img_type}")
         return test_cases
     # TODO: make images generate a superdisk manifest with pipelines for

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -4,11 +4,14 @@ import platform
 # supported images that can be directly booted
 QEMU_BOOT_IMAGE_TYPES = ("qcow2", "raw")
 
-# supported images that can be booted in a cloud
-CLOUD_BOOT_IMAGE_TYPES = ("ami",)
-
 # images that can *not* be booted directly from qemu
 NON_QEMU_BOOT_IMAGE_TYPES = ("vmdk",)
+
+# disk image types can be build from a single manifest
+DISK_IMAGE_TYPES = QEMU_BOOT_IMAGE_TYPES + NON_QEMU_BOOT_IMAGE_TYPES
+
+# supported images that can be booted in a cloud
+CLOUD_BOOT_IMAGE_TYPES = ("ami",)
 
 # supported images that require an install
 INSTALLER_IMAGE_TYPES = ("anaconda-iso",)
@@ -64,14 +67,11 @@ def gen_testcases(what):
                     INSTALLER_IMAGE_TYPES:
                 test_cases.append(f"{cnt},{img_type}")
         return test_cases
-    # TODO: make images generate a superdisk manifest with pipelines for
-    #       qcow2+vmdk+raw so that we can just generate them all via a
-    #       single build
     elif what == "multidisk":
         # single test that specifies all image types
         test_cases = []
         for cnt in CONTAINERS_TO_TEST.values():
-            img_type = "+".join(QEMU_BOOT_IMAGE_TYPES)
+            img_type = "+".join(DISK_IMAGE_TYPES)
             test_cases.append(f"{cnt},{img_type}")
         return test_cases
     raise ValueError(f"unknown test-case type {what}")


### PR DESCRIPTION
The vmdk images cannot be booted easily in qemu so we will just
check that the image is there but do no functional testing.

This is a followup for https://github.com/osbuild/bootc-image-builder/pull/251

