### PR TITLE
workflow: cancel in-progress tests on PR updates (HMS-3697)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,10 @@ on:
   # for merge queue
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: "⌨ Lint"


### PR DESCRIPTION
Similar to the osbuild PR#1636 this comit cancels CI runs for PRs that got updated.

This changes the behavior in a way that whenever a PR gets updated all still-in-progress runs get canceled and new runs get spawned.