### PR TITLE
uploader: test the progress upload output with a regex

### DIFF
--- a/bib/internal/uploader/aws_test.go
+++ b/bib/internal/uploader/aws_test.go
@@ -81,6 +81,6 @@ func TestUploadAndRegisterProgressBar(t *testing.T) {
 	assert.Equal(t, fakeUploader.registerCalled, 1)
 
 	assert.Contains(t, fakeStdout.String(), "Uploading ")
-	assert.Contains(t, fakeStdout.String(), "10.00 MiB / 10.00 MiB [============================================] 100.00%")
+	assert.Regexp(t, `10.00 MiB / 10.00 MiB \[=+\] 100.00%`, fakeStdout.String())
 	assert.Contains(t, fakeStdout.String(), "Registering AMI ")
 }


### PR DESCRIPTION
The length of the progress bar depends on the terminal width so let's make the test matching flexible.