### PR TITLE
Use the all-manifest for disk image builds

### DIFF
--- a/bib/cmd/bootc-image-builder/build_type.go
+++ b/bib/cmd/bootc-image-builder/build_type.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+)
+
+type BuildType int
+
+const (
+	BuildTypeDisk BuildType = iota + 1
+	BuildTypeISO
+)
+
+var supportedImageTypes = map[string]BuildType{
+	"ami":          BuildTypeDisk,
+	"qcow2":        BuildTypeDisk,
+	"raw":          BuildTypeDisk,
+	"vmdk":         BuildTypeDisk,
+	"anaconda-iso": BuildTypeISO,
+	"iso":          BuildTypeISO,
+}
+
+func NewBuildType(imageTypes []string) (BuildType, error) {
+	if len(imageTypes) == 0 {
+		return 0, fmt.Errorf("cannot convert empty array of image types")
+	}
+
+	buildType := supportedImageTypes[imageTypes[0]]
+	for _, typ := range imageTypes {
+		if bt, ok := supportedImageTypes[typ]; ok {
+			if buildType != bt { // build types can't be mixed
+				return 0, fmt.Errorf("cannot build %q with different target types", typ)
+			}
+		} else {
+			return 0, fmt.Errorf("NewBuildType(): unsupported image type %q", typ)
+		}
+
+	}
+
+	return supportedImageTypes[imageTypes[0]], nil
+}

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -90,33 +90,16 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 
 	img.SysrootReadOnly = true
 
-	var imageFormat platform.ImageFormat
-	var filename string
-	switch c.ImgType {
-	case "qcow2":
-		imageFormat = platform.FORMAT_QCOW2
-		filename = "disk.qcow2"
-	case "ami", "raw":
-		imageFormat = platform.FORMAT_RAW
-		filename = "disk.raw"
-	case "vmdk":
-		imageFormat = platform.FORMAT_VMDK
-		filename = "disk.vmdk"
-	}
-
 	switch c.Architecture {
 	case arch.ARCH_X86_64:
 		img.Platform = &platform.X86{
-			BasePlatform: platform.BasePlatform{
-				ImageFormat: imageFormat,
-			},
-			BIOS: true,
+			BasePlatform: platform.BasePlatform{},
+			BIOS:         true,
 		}
 	case arch.ARCH_AARCH64:
 		img.Platform = &platform.Aarch64{
 			UEFIVendor: "fedora",
 			BasePlatform: platform.BasePlatform{
-				ImageFormat: imageFormat,
 				QCOW2Compat: "1.1",
 			},
 		}
@@ -136,7 +119,9 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 	}
 	img.PartitionTable = pt
 
-	img.Filename = filename
+	// For the bootc-disk image, the filename is the basename and the extension
+	// is added automatically for each disk format
+	img.Filename = "disk"
 
 	mf := manifest.New()
 	mf.Distro = manifest.DISTRO_FEDORA

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -26,10 +26,7 @@ type ManifestConfig struct {
 	// OCI image path (without the transport, that is always docker://)
 	Imgref string
 
-	// Image type to build (currently: qcow2, ami)
-	//
-	// TODO: Make this an enum.
-	ImgType string
+	BuildType BuildType
 
 	// Build config
 	Config *BuildConfig
@@ -50,13 +47,13 @@ type ManifestConfig struct {
 func Manifest(c *ManifestConfig) (*manifest.Manifest, error) {
 	rng := createRand()
 
-	switch c.ImgType {
-	case "ami", "qcow2", "raw", "vmdk":
+	switch c.BuildType {
+	case BuildTypeDisk:
 		return manifestForDiskImage(c, rng)
-	case "anaconda-iso", "iso":
+	case BuildTypeISO:
 		return manifestForISO(c, rng)
 	default:
-		return nil, fmt.Errorf("Manifest(): unsupported image type %q", c.ImgType)
+		return nil, fmt.Errorf("Manifest(): unknown build type %d", c.BuildType)
 	}
 }
 

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -149,7 +149,7 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 			Local:     c.Local,
 		},
 	}
-	_, err = img.InstantiateManifestFromContainers(&mf, containerSources, runner, rng)
+	err = img.InstantiateManifestFromContainers(&mf, containerSources, runner, rng)
 
 	return &mf, err
 }

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -223,17 +223,10 @@ func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, error) {
 		config = &BuildConfig{}
 	}
 
-	// Disk image types should all share mostly the same manifest but with
-	// different export pipelines.
-	// Right now the qcow2 contains all the pipelines required for ami and raw,
-	// so if one of the image types is qcow2, build that and export pipelines
-	// accordingly if needed.
-	// NOTE: THIS WILL CHANGE WITH THE INTRODUCTION OF NEW IMAGE TYPES
+	// Disk image types all share the same manifest but with different export pipelines.
+	// ISO images can't be built alongside other image types.
+	// Therefore, the first element is enough.
 	imgType := imgTypes[0]
-	if slices.Contains(imgTypes, "qcow2") {
-		imgType = "qcow2"
-	}
-
 	manifestConfig := &ManifestConfig{
 		Architecture: buildArch,
 		Config:       config,

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -317,7 +317,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 			// this might be appended more than once, but that's okay
 			exports = append(exports, "image")
 		case "vmdk":
-			exports = []string{"vmdk"}
+			exports = append(exports, "vmdk")
 
 		case "anaconda-iso", "iso":
 			exports = append(exports, "bootiso")

--- a/bib/cmd/bootc-image-builder/main_test.go
+++ b/bib/cmd/bootc-image-builder/main_test.go
@@ -53,7 +53,7 @@ func TestCanChownInPathCannotChange(t *testing.T) {
 
 type manifestTestCase struct {
 	config     *main.ManifestConfig
-	imageType  string
+	imageTypes []string
 	packages   map[string][]rpmmd.PackageSpec
 	containers map[string][]container.Spec
 	expStages  map[string][]string
@@ -70,8 +70,8 @@ func getUserConfig() *main.ManifestConfig {
 	pass := "super-secret-password-42"
 	key := "ssh-ed25519 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 	return &main.ManifestConfig{
-		Imgref:  "testuser",
-		ImgType: "",
+		Imgref:    "testuser",
+		BuildType: 0,
 		Config: &main.BuildConfig{
 			Blueprint: &blueprint.Blueprint{
 				Customizations: &blueprint.Customizations{
@@ -92,38 +92,35 @@ func TestManifestGenerationEmptyConfig(t *testing.T) {
 	baseConfig := getBaseConfig()
 	testCases := map[string]manifestTestCase{
 		"ami-base": {
-			config:    baseConfig,
-			imageType: "ami",
+			config:     baseConfig,
+			imageTypes: []string{"ami"},
 		},
 		"raw-base": {
-			config:    baseConfig,
-			imageType: "raw",
+			config:     baseConfig,
+			imageTypes: []string{"raw"},
 		},
 		"qcow2-base": {
-			config:    baseConfig,
-			imageType: "qcow2",
+			config:     baseConfig,
+			imageTypes: []string{"qcow2"},
 		},
 		"iso-base": {
-			config:    baseConfig,
-			imageType: "iso",
+			config:     baseConfig,
+			imageTypes: []string{"iso"},
 		},
 		"empty-config": {
-			config:    &main.ManifestConfig{},
-			imageType: "qcow2",
-			err:       errors.New("pipeline: no base image defined"),
-		},
-		"bad-image-type": {
-			config:    baseConfig,
-			imageType: "bad",
-			err:       errors.New("Manifest(): unsupported image type \"bad\""),
+			config:     &main.ManifestConfig{},
+			imageTypes: []string{"qcow2"},
+			err:        errors.New("pipeline: no base image defined"),
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			config := main.ManifestConfig(*tc.config)
-			config.ImgType = tc.imageType
-			_, err := main.Manifest(&config)
+			bt, err := main.NewBuildType(tc.imageTypes)
+			assert.NoError(t, err)
+			config.BuildType = bt
+			_, err = main.Manifest(&config)
 			assert.Equal(t, err, tc.err)
 		})
 	}
@@ -133,28 +130,30 @@ func TestManifestGenerationUserConfig(t *testing.T) {
 	userConfig := getUserConfig()
 	testCases := map[string]manifestTestCase{
 		"ami-user": {
-			config:    userConfig,
-			imageType: "ami",
+			config:     userConfig,
+			imageTypes: []string{"ami"},
 		},
 		"raw-user": {
-			config:    userConfig,
-			imageType: "raw",
+			config:     userConfig,
+			imageTypes: []string{"raw"},
 		},
 		"qcow2-user": {
-			config:    userConfig,
-			imageType: "qcow2",
+			config:     userConfig,
+			imageTypes: []string{"qcow2"},
 		},
 		"iso-user": {
-			config:    userConfig,
-			imageType: "iso",
+			config:     userConfig,
+			imageTypes: []string{"iso"},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			config := main.ManifestConfig(*tc.config)
-			config.ImgType = tc.imageType
-			_, err := main.Manifest(&config)
+			bt, err := main.NewBuildType(tc.imageTypes)
+			assert.NoError(t, err)
+			config.BuildType = bt
+			_, err = main.Manifest(&config)
 			assert.NoError(t, err)
 		})
 	}
@@ -227,7 +226,7 @@ func TestManifestSerialization(t *testing.T) {
 	testCases := map[string]manifestTestCase{
 		"ami-base": {
 			config:     baseConfig,
-			imageType:  "ami",
+			imageTypes: []string{"ami"},
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
@@ -244,7 +243,7 @@ func TestManifestSerialization(t *testing.T) {
 		},
 		"raw-base": {
 			config:     baseConfig,
-			imageType:  "raw",
+			imageTypes: []string{"raw"},
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
@@ -261,7 +260,7 @@ func TestManifestSerialization(t *testing.T) {
 		},
 		"qcow2-base": {
 			config:     baseConfig,
-			imageType:  "qcow2",
+			imageTypes: []string{"qcow2"},
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
@@ -278,7 +277,7 @@ func TestManifestSerialization(t *testing.T) {
 		},
 		"ami-user": {
 			config:     userConfig,
-			imageType:  "ami",
+			imageTypes: []string{"ami"},
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
@@ -293,7 +292,7 @@ func TestManifestSerialization(t *testing.T) {
 		},
 		"raw-user": {
 			config:     userConfig,
-			imageType:  "raw",
+			imageTypes: []string{"raw"},
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
@@ -308,7 +307,7 @@ func TestManifestSerialization(t *testing.T) {
 		},
 		"qcow2-user": {
 			config:     userConfig,
-			imageType:  "qcow2",
+			imageTypes: []string{"qcow2"},
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
@@ -323,7 +322,7 @@ func TestManifestSerialization(t *testing.T) {
 		},
 		"iso-user": {
 			config:     userConfig,
-			imageType:  "iso",
+			imageTypes: []string{"iso"},
 			containers: isoContainers,
 			packages:   isoPackages,
 			expStages: map[string][]string{
@@ -333,31 +332,31 @@ func TestManifestSerialization(t *testing.T) {
 		},
 		"iso-nobuildpkg": {
 			config:     userConfig,
-			imageType:  "iso",
+			imageTypes: []string{"iso"},
 			containers: isoContainers,
 			packages:   pkgsNoBuild,
 			err:        "serialization not started",
 		},
 		"iso-nocontainer": {
-			config:    userConfig,
-			imageType: "iso",
-			packages:  isoPackages,
-			err:       "missing ostree, container, or ospipeline parameters in ISO tree pipeline",
+			config:     userConfig,
+			imageTypes: []string{"iso"},
+			packages:   isoPackages,
+			err:        "missing ostree, container, or ospipeline parameters in ISO tree pipeline",
 		},
 		"ami-nocontainer": {
-			config:    userConfig,
-			imageType: "ami",
-			err:       "pipeline ostree-deployment requires exactly one ostree commit or one container (have commits: []; containers: [])",
+			config:     userConfig,
+			imageTypes: []string{"ami"},
+			err:        "pipeline ostree-deployment requires exactly one ostree commit or one container (have commits: []; containers: [])",
 		},
 		"raw-nocontainer": {
-			config:    userConfig,
-			imageType: "raw",
-			err:       "pipeline ostree-deployment requires exactly one ostree commit or one container (have commits: []; containers: [])",
+			config:     userConfig,
+			imageTypes: []string{"raw"},
+			err:        "pipeline ostree-deployment requires exactly one ostree commit or one container (have commits: []; containers: [])",
 		},
 		"qcow2-nocontainer": {
-			config:    userConfig,
-			imageType: "qcow2",
-			err:       "pipeline ostree-deployment requires exactly one ostree commit or one container (have commits: []; containers: [])",
+			config:     userConfig,
+			imageTypes: []string{"qcow2"},
+			err:        "pipeline ostree-deployment requires exactly one ostree commit or one container (have commits: []; containers: [])",
 		},
 	}
 
@@ -366,7 +365,9 @@ func TestManifestSerialization(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			config := main.ManifestConfig(*tc.config)
-			config.ImgType = tc.imageType
+			bt, err := main.NewBuildType(tc.imageTypes)
+			assert.NoError(err)
+			config.BuildType = bt
 			mf, err := main.Manifest(&config)
 			assert.NoError(err) // this isn't the error we're testing for
 
@@ -388,7 +389,7 @@ func TestManifestSerialization(t *testing.T) {
 		t.Run("iso-nopkgs", func(t *testing.T) {
 			assert := assert.New(t)
 			config := main.ManifestConfig(*userConfig)
-			config.ImgType = "iso"
+			config.BuildType, _ = main.NewBuildType([]string{"iso"})
 			manifest, err := main.Manifest(&config)
 			assert.NoError(err) // this isn't the error we're testing for
 
@@ -458,4 +459,71 @@ func checkStages(serialized manifest.OSBuildManifest, pipelineStages map[string]
 	}
 
 	return nil
+}
+
+type buildTypeTestCase struct {
+	imageTypes []string
+	buildType  main.BuildType
+	err        error
+}
+
+func TestBuildType(t *testing.T) {
+	testCases := map[string]buildTypeTestCase{
+		"qcow-disk": {
+			imageTypes: []string{"qcow2"},
+			buildType:  main.BuildTypeDisk,
+		},
+		"ami-disk": {
+			imageTypes: []string{"ami"},
+			buildType:  main.BuildTypeDisk,
+		},
+		"qcow-ami-disk": {
+			imageTypes: []string{"qcow2", "ami"},
+			buildType:  main.BuildTypeDisk,
+		},
+		"ami-raw": {
+			imageTypes: []string{"ami", "raw"},
+			buildType:  main.BuildTypeDisk,
+		},
+		"all-disk": {
+			imageTypes: []string{"ami", "raw", "vmdk", "qcow2"},
+			buildType:  main.BuildTypeDisk,
+		},
+		"iso": {
+			imageTypes: []string{"iso"},
+			buildType:  main.BuildTypeISO,
+		},
+		"anaconda": {
+			imageTypes: []string{"anaconda-iso"},
+			buildType:  main.BuildTypeISO,
+		},
+		"bad-mix": {
+			imageTypes: []string{"vmdk", "anaconda-iso"},
+			err:        errors.New("cannot build \"anaconda-iso\" with different target types"),
+		},
+		"bad-mix-part-2": {
+			imageTypes: []string{"ami", "iso"},
+			err:        errors.New("cannot build \"iso\" with different target types"),
+		},
+		"bad-image-type": {
+			imageTypes: []string{"bad"},
+			err:        errors.New("NewBuildType(): unsupported image type \"bad\""),
+		},
+		"bad-in-good": {
+			imageTypes: []string{"ami", "raw", "vmdk", "qcow2", "something-else-what-is-this"},
+			err:        errors.New("NewBuildType(): unsupported image type \"something-else-what-is-this\""),
+		},
+		"all-bad": {
+			imageTypes: []string{"bad1", "bad2", "bad3", "bad4", "bad5", "bad42"},
+			err:        errors.New("NewBuildType(): unsupported image type \"bad1\""),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bt, err := main.NewBuildType(tc.imageTypes)
+			assert.Equal(t, err, tc.err)
+			assert.Equal(t, bt, tc.buildType)
+		})
+	}
 }

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.50.36
 	github.com/cheggaaa/pb v1.0.29
 	github.com/google/uuid v1.6.0
-	github.com/osbuild/images v0.44.0
+	github.com/osbuild/images v0.46.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -280,6 +280,8 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/osbuild/images v0.44.0 h1:Hg/n2PeWOWPx9naVDPao6TC4B/9LAy58L+EmR2yj/TE=
 github.com/osbuild/images v0.44.0/go.mod h1:eM/J8+hEUH0jrwcy3DtE6SDg+bRMWFZIf5d+YDyhoDY=
+github.com/osbuild/images v0.46.0 h1:SfUGmVwXNinhT+19OAuDXOf9VRG+F9G6R4yctIIwLTs=
+github.com/osbuild/images v0.46.0/go.mod h1:eM/J8+hEUH0jrwcy3DtE6SDg+bRMWFZIf5d+YDyhoDY=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=


### PR DESCRIPTION
_Requires osbuild/images#512_

The bootc-disk image manifest now always contains all pipelines needed to generate all image types. This way we can build any combination of disk images depending on what we need to export without needing to conditionally add or remove pipelines.

Set the filename as just "disk" since extensions are added automatically for each file.