### PR TITLE
main: check if local storage is mounted when `--local` flag is used (HMS-3792)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,20 @@ sudo podman run \
     --security-opt label=type:unconfined_t \
     -v $(pwd)/config.json:/config.json \
     -v $(pwd)/output:/output \
+    -v /var/lib/containers/storage:/var/lib/containers/storage \
     quay.io/centos-bootc/bootc-image-builder:latest \
     --type qcow2 \
     --config /config.json \
     quay.io/centos-bootc/fedora-bootc:eln
 ```
 
+NOTE: local storage is being used by default. If the `--local` flag is not provided, as in the above example,
+the latest image will be pulled into the local storage.
+
 ### Using local containers
 
-To use containers from local container's storage rather than a registry, we need to ensure two things:
-- the container exists in local storage
-- mount the local container storage
-
-Since the container is run in `rootful` only root container storage paths are allowed.
+To skip pulling an image into local storage and use an existing container image, the `--local` flag can be used,
+as below:
 
 ```bash
 sudo podman run \
@@ -63,15 +64,12 @@ sudo podman run \
     --security-opt label=type:unconfined_t \
     -v $(pwd)/config.json:/config.json \
     -v $(pwd)/output:/output \
-    -v /var/lib/containers/storage:/var/lib/containers/storage \
     quay.io/centos-bootc/bootc-image-builder:latest \
     --type qcow2 \
     --config /config.json \
     --local \
     localhost/bootc:eln
 ```
-
-When using the --local flag, we need to mount the storage path as a volume. With this enabled, it is assumed that the target container is in the container storage.
 
 ### Running the resulting QCOW2 file on Linux (x86_64)
 

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -40,7 +40,7 @@ type ManifestConfig struct {
 	// TLSVerify specifies whether HTTPS and a valid TLS certificate are required
 	TLSVerify bool
 
-	// Use a local container from the host rather than a repository
+	// Use a local container image from the host storage rather than a repository
 	Local bool
 }
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/osbuild/bootc-image-builder/pull/120 and addresses some of the comments on the PR.

The most notable change is switching to use local storage as the default. A helper function is introduced to check if the image is in the local store and, if not, copy it into the store.