### PR TITLE
main: Auto-generate help for image types

### DIFF
--- a/bib/cmd/bootc-image-builder/build_type.go
+++ b/bib/cmd/bootc-image-builder/build_type.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 )
 
 type BuildType int
@@ -17,7 +18,11 @@ var supportedImageTypes = map[string]BuildType{
 	"raw":          BuildTypeDisk,
 	"vmdk":         BuildTypeDisk,
 	"anaconda-iso": BuildTypeISO,
-	"iso":          BuildTypeISO,
+}
+
+// imageTypeAliases contains aliases for our images
+var imageTypeAliases = map[string]string{
+	"iso": "anaconda-iso", // deprecated
 }
 
 func NewBuildType(imageTypes []string) (BuildType, error) {
@@ -38,4 +43,22 @@ func NewBuildType(imageTypes []string) (BuildType, error) {
 	}
 
 	return supportedImageTypes[imageTypes[0]], nil
+}
+
+// allImageTypesString returns a comma-separated list of supported types
+func allImageTypesString() string {
+	keys := make([]string, 0, len(supportedImageTypes))
+	for k := range supportedImageTypes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	r := ""
+	for i, k := range keys {
+		if i > 0 {
+			r += ", "
+		}
+		r += k
+	}
+	return r
 }

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -306,7 +306,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		case "anaconda-iso", "iso":
 			exports = append(exports, "bootiso")
 		default:
-			return fmt.Errorf("valid types are 'qcow2', 'ami', 'raw', 'vdmk', 'anaconda-iso', not: '%s'", imgType)
+			return fmt.Errorf("valid types are %s, not: '%s'", allImageTypesString(), imgType)
 		}
 	}
 	manifestPath := filepath.Join(outputDir, manifest_fname)
@@ -407,7 +407,7 @@ func run() error {
 	manifestCmd.Flags().String("config", "", "build config file")
 	manifestCmd.Flags().String("rpmmd", "/rpmmd", "rpm metadata cache directory")
 	manifestCmd.Flags().String("target-arch", "", "build for the given target architecture (experimental)")
-	manifestCmd.Flags().StringArray("type", []string{"qcow2"}, "image types to build [qcow2, ami, iso, raw]")
+	manifestCmd.Flags().StringArray("type", []string{"qcow2"}, fmt.Sprintf("image types to build [%s]", allImageTypesString()))
 	manifestCmd.Flags().Bool("local", false, "use a local container rather than a container from a registry")
 
 	logrus.SetLevel(logrus.ErrorLevel)


### PR DESCRIPTION
I forgot to add `vmdk` there.  This reduces the number of sources of truth for image types.