### PR TITLE
bib: respect the root fs type from the container

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -123,15 +123,7 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 	mf := manifest.New()
 	mf.Distro = manifest.DISTRO_FEDORA
 	runner := &runner.Linux{}
-	containerSources := []container.SourceSpec{
-		{
-			Source:    c.Imgref,
-			Name:      c.Imgref,
-			TLSVerify: &c.TLSVerify,
-			Local:     true,
-		},
-	}
-	err = img.InstantiateManifestFromContainers(&mf, containerSources, runner, rng)
+	err = img.InstantiateManifestFromContainers(&mf, []container.SourceSpec{containerSource}, runner, rng)
 
 	return &mf, err
 }

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -65,7 +65,7 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 		Source:    c.Imgref,
 		Name:      c.Imgref,
 		TLSVerify: &c.TLSVerify,
-		Local:     c.Local,
+		Local:     true,
 	}
 
 	var customizations *blueprint.Customizations
@@ -128,7 +128,7 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 			Source:    c.Imgref,
 			Name:      c.Imgref,
 			TLSVerify: &c.TLSVerify,
-			Local:     c.Local,
+			Local:     true,
 		},
 	}
 	err = img.InstantiateManifestFromContainers(&mf, containerSources, runner, rng)
@@ -145,7 +145,7 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 		Source:    c.Imgref,
 		Name:      c.Imgref,
 		TLSVerify: &c.TLSVerify,
-		Local:     c.Local,
+		Local:     true,
 	}
 
 	// The ref is not needed and will be removed from the ctor later

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -298,7 +298,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	}
 
 	manifest_fname := fmt.Sprintf("manifest-%s.json", strings.Join(imgTypes, "-"))
-	fmt.Printf("Generating %s ... ", manifest_fname)
+	fmt.Printf("Generating manifest %s\n", manifest_fname)
 	mf, err := manifestFromCobra(cmd, args)
 	if err != nil {
 		panic(err)

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -266,7 +266,8 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
                 break
             print(line, end="")
             bib_output += line
-        p.wait(timeout=10)
+        rc = p.wait(timeout=10)
+        assert rc == 0, f"bootc-image-builder failed with return code {rc}"
 
     journal_output = testutil.journal_after_cursor(cursor)
     metadata = {}

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -7,6 +7,8 @@ import testutil
 
 if not testutil.has_executable("podman"):
     pytest.skip("no podman, skipping integration tests that required podman", allow_module_level=True)
+if not testutil.can_start_rootful_containers():
+    pytest.skip("tests require to be able to run rootful containers (try: sudo)", allow_module_level=True)
 
 from containerbuild import build_container_fixture  # noqa: F401
 from testcases import gen_testcases
@@ -19,6 +21,8 @@ def test_manifest_smoke(build_container, testcase_ref):
 
     output = subprocess.check_output([
         "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
         f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "{container_ref}"]',
         build_container,
     ])


### PR DESCRIPTION
Needs #262 or an alternative, this is mostly a showcase of how bib can be expanded after we can actually run the container.

Prior to this commit, we always assumed that the root fs is ext4. However, it's possible to redefine this in the container, so let's respect this.