### PR TITLE
build: Add .dockerignore and a comment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+bin
+devel
+plans
+test

--- a/devel/Containerfile.hack
+++ b/devel/Containerfile.hack
@@ -11,5 +11,6 @@
 #
 # make && podman build --no-cache -t localhost/bib -v $(pwd)/bin:/srcbin -f devel/Containerfile.hack .
 #
+# (The use of the explicit bind mount here is to bypass .dockerignore)
 FROM quay.io/centos-bootc/bootc-image-builder:latest
 RUN install /srcbin/bootc-image-builder /usr/bin


### PR DESCRIPTION
It's best practice to trim out stuff we don't need in the container build from the context directory; this way if I e.g. edit `tests` it won't invalidate the build caches.

Similarly, it's a really good idea to exclude things like `bin/` from the builds - you don't want to accidentally somehow be using incorrect cached *final* binaries.

But `Containerfile.hack` is all about bypassing that, so add a comment for why we use the bind mount.