### PR TITLE
bib: add --filesystems commandline option for basic customizations

### DIFF
--- a/bib/cmd/bootc-image-builder/export_test.go
+++ b/bib/cmd/bootc-image-builder/export_test.go
@@ -1,6 +1,9 @@
 package main
 
-var CanChownInPath = canChownInPath
+var (
+	CanChownInPath                       = canChownInPath
+	NewFilesystemCustomizationFromString = newFilesystemCustomizationFromString
+)
 
 func MockOsGetuid(new func() int) (restore func()) {
 	saved := osGetuid

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -42,6 +42,10 @@ type ManifestConfig struct {
 
 	// Use a local container from the host rather than a repository
 	Local bool
+
+	// The default filesystem size
+	// TODO: support type as well
+	Filesystems []blueprint.FilesystemCustomization
 }
 
 func Manifest(c *ManifestConfig) (*manifest.Manifest, error) {
@@ -110,7 +114,7 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 	if !ok {
 		return nil, fmt.Errorf("pipelines: no partition tables defined for %s", c.Architecture)
 	}
-	pt, err := disk.NewPartitionTable(&basept, nil, DEFAULT_SIZE, disk.RawPartitioningMode, nil, rng)
+	pt, err := disk.NewPartitionTable(&basept, c.Filesystems, DEFAULT_SIZE, disk.RawPartitioningMode, nil, rng)
 	if err != nil {
 		return nil, err
 	}

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	code.cloudfoundry.org/bytefmt v0.0.0-20240318154019-470077afc6dc // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
@@ -105,12 +106,12 @@ require (
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
-	golang.org/x/mod v0.13.0 // indirect
+	golang.org/x/mod v0.16.0 // indirect
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/tools v0.14.0 // indirect
+	golang.org/x/tools v0.19.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240304161311-37d4d3c04a78 // indirect
 	google.golang.org/grpc v1.62.0 // indirect
 	google.golang.org/protobuf v1.32.0 // indirect

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+code.cloudfoundry.org/bytefmt v0.0.0-20240318154019-470077afc6dc h1:KTXwvKQ94jsSsKbT23FO3/wb1nNRZTOH0js9/PfSel0=
+code.cloudfoundry.org/bytefmt v0.0.0-20240318154019-470077afc6dc/go.mod h1:JJ+p2lgTjXP0zB6fShYUwYHuGnDvxEjJRcpqIESTSao=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774 h1:SCbEWT58NSt7d2mcFdvxC9uyrdcTfvBbPLThhkDmXzg=
@@ -401,6 +403,8 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
 golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=
+golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -469,6 +473,8 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.14.0 h1:jvNa2pY0M4r62jkRQ6RwEZZyPcymeL9XZMLBbV7U2nc=
 golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg=
+golang.org/x/tools v0.19.0 h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw=
+golang.org/x/tools v0.19.0/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -247,6 +247,7 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
             *creds_args,
             build_container,
             container_ref,
+            "--filesystems", "/:12G",
             "--config", "/output/config.json",
             *types_arg,
             *upload_args,
@@ -324,6 +325,7 @@ def test_image_boots(image_type):
         exit_status, output = test_vm.run("echo hello", user=image_type.username, password=image_type.password)
         assert exit_status == 0
         assert "hello" in output
+        # TODO: check the root FS size here to see that we really got 12G
 
 
 @pytest.mark.parametrize("image_type", gen_testcases("ami-boot"), indirect=["image_type"])


### PR DESCRIPTION
[draft so that we can discuss the stawman commandline that is inspired by Dans (thanks!)  suggestion]

This commit adds support for basic filesystem customization. The main use-case right now is to allow to create a bigger default rootfs. This can be done via:
```
$ bootc-image-builder --filesystems "/:20G"
```
This is conceptually very similar to PR#124 but instead of blueprints it is purely commandline driven. The rational is that it's unclear what customization format we eventually want to support but it is clear that we need a way to drive this from the commandline.

The format is designed to be extensible to a certain extend, so
```
bib --filesystems "/:20G,/var:100G:xfs"
```
is currently a strawman for supporting more customizations in the future.

This PR is limited to "/" because we currently have no way to inject /etc/fstab or systemd-mount units (the bootc --copy-etc PR will probably helper here in the future).