### PR TITLE
bib: make /var/lib/containers/storage a volume

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -25,3 +25,4 @@ VOLUME /output
 WORKDIR /output
 VOLUME /store
 VOLUME /rpmmd
+VOLUME /var/lib/containers/storage


### PR DESCRIPTION
6e965d2413f7bdc8844bf09c9c9968c6c170d96d changed bib to always go
through a container storage. However, if the container runtime running
bib was using overlayfs (the default), we ended up in a situation that
/var/lib/containers/storage was overlayfs. When bib itself tried to
worked with these containers, it called podman/skopeo that tried to
create overlayfs inside overlayfs, which is a forbidden combination.

This worked by accident with centos-boocs/fedora and centos containers,
because they contain fuse-overlayfs, and podman/skopeo apparently
silently switched to using fuse. This isn't only slow, but it also
didn't work with container images without fuse-overlayfs. One example
of such an image is the iot-bootable-container. E.g.
registry.gitlab.com/redhat/services/products/image-builder/ci/images/iot-bootable-container:fedora-39-x86_64-49d623cc26287730f87d4c9eebadefd2b180dea8a41b00efe7f3b1c636f221d7

Let's fix this by making /var/lib/containers/storage a proper volume,
which means that this directory will be bind-mounted to a real
filesystem by the container engine, instead of being on an overlay.

I tested this by successfully building a disk image from the
iot-bootable-container container image above.