### PR TITLE
build: Enable prefetch of go deps in konflux pipeline

### DIFF
--- a/.tekton/bootc-image-builder-pull-request.yaml
+++ b/.tekton/bootc-image-builder-pull-request.yaml
@@ -104,7 +104,7 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
-      - default: ""
+      - default: "gomod"
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
         type: string

--- a/.tekton/bootc-image-builder-push.yaml
+++ b/.tekton/bootc-image-builder-push.yaml
@@ -101,7 +101,7 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
-      - default: ""
+      - default: "gomod"
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
         type: string


### PR DESCRIPTION
This supports the building of source containers.

We want to enable the "hermetic" parameter also, but since rpm content is being installed that won't be possible until
https://issues.redhat.com/browse/KONFLUX-1318 completes.