### PR TITLE
test: map /var/lib/containers/storage when running bib

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -233,6 +233,7 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
             "podman", "run", "--rm",
             "--privileged",
             "--security-opt", "label=type:unconfined_t",
+            "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
             "-v", f"{output_path}:/output",
             "-v", "/store",  # share the cache between builds
         ]


### PR DESCRIPTION
Now that we always pull the containers this may speed up things when layers are found in the container storage.

I finally measured this, at least locally it has a noticable effect. I tested a single run of 
```
$ sudo pytest -s -vv './test/test_build.py::test_image_boots[quay.io/centos-bootc/centos-bootc:stream9,raw]'
```
- with the patch a single test run  takes `2:39min` on my system
- without `4:40min` 