### PR TITLE
Revert "build: Enable prefetch of go deps in konflux pipeline"

### DIFF
--- a/.tekton/bootc-image-builder-pull-request.yaml
+++ b/.tekton/bootc-image-builder-pull-request.yaml
@@ -104,7 +104,7 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
-      - default: "gomod"
+      - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
         type: string

--- a/.tekton/bootc-image-builder-push.yaml
+++ b/.tekton/bootc-image-builder-push.yaml
@@ -101,7 +101,7 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
-      - default: "gomod"
+      - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
         type: string


### PR DESCRIPTION
This reverts commit dfdc210238f7f6c2b6c2dd06ed0ace8246b11da3.

Since this commit, all Konflux pipelines are failing. Let's try
reverting it to see if it fixes the issue.

cc @ralphbean 