### PR TITLE
README: update local storage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,20 @@ sudo podman run \
     --security-opt label=type:unconfined_t \
     -v $(pwd)/config.json:/config.json \
     -v $(pwd)/output:/output \
+    -v /var/lib/containers/storage:/var/lib/containers/storage \
     quay.io/centos-bootc/bootc-image-builder:latest \
     --type qcow2 \
     --config /config.json \
     quay.io/centos-bootc/fedora-bootc:eln
 ```
 
+NOTE: local storage is being used by default. If the `--local` flag is not provided, as in the above example,
+the latest image will be pulled into the local storage.
+
 ### Using local containers
 
-To use containers from local container's storage rather than a registry, we need to ensure two things:
-- the container exists in local storage
-- mount the local container storage
-
-Since the container is run in `rootful` only root container storage paths are allowed.
+To skip pulling an image into local storage and use an existing container image, the `--local` flag can be used,
+as below:
 
 ```bash
 sudo podman run \
@@ -70,8 +71,6 @@ sudo podman run \
     --local \
     localhost/bootc:eln
 ```
-
-When using the --local flag, we need to mount the storage path as a volume. With this enabled, it is assumed that the target container is in the container storage.
 
 ### Running the resulting QCOW2 file on Linux (x86_64)
 

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -40,7 +40,7 @@ type ManifestConfig struct {
 	// TLSVerify specifies whether HTTPS and a valid TLS certificate are required
 	TLSVerify bool
 
-	// Use a local container from the host rather than a repository
+	// Use a local container image from the host storage rather than a repository
 	Local bool
 
 	// Only the "/" filesystem size is configured here right now

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -77,10 +77,7 @@ def image_type_fixture(shared_tmpdir, build_container, request, force_aws_upload
     """
     container_ref, images, target_arch, local = parse_request_params(request)
 
-    if not local:
-        with build_images(shared_tmpdir, build_container, request, force_aws_upload) as build_results:
-            yield build_results[0]
-    else:
+    if local:
         cont_tag = "localhost/cont-base-" + "".join(random.choices(string.digits, k=12))
 
         # we are not cross-building local images (for now)
@@ -93,8 +90,8 @@ def image_type_fixture(shared_tmpdir, build_container, request, force_aws_upload
             f"containers-storage:[overlay@/var/lib/containers/storage+/run/containers/storage]{cont_tag}"
         ])
 
-        with build_images(shared_tmpdir, build_container, request, force_aws_upload) as build_results:
-            yield build_results[0]
+    with build_images(shared_tmpdir, build_container, request, force_aws_upload) as build_results:
+        yield build_results[0]
 
 
 @pytest.fixture(name="images", scope="session")


### PR DESCRIPTION
Since we are always pulling the latest image by default the container image will always be in the host's local storage. Update the readme to reflect this.

Additionally, address one or two of the minor comments from https://github.com/osbuild/bootc-image-builder/pull/120.