### PR TITLE
bib: switch to use `bootc install to-filesystem` (HMS-3453)

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -261,8 +261,6 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 		},
 	}
 
-	img.ISOLabelTmpl = "Container-Installer-%s"
-
 	var customizations *blueprint.Customizations
 	if c.Config != nil && c.Config.Blueprint != nil {
 		customizations = c.Config.Blueprint.Customizations

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -78,8 +78,6 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 
 	img := image.NewBootcDiskImage(containerSource)
 	img.Users = users.UsersFromBP(customizations.GetUsers())
-	img.Groups = users.GroupsFromBP(customizations.GetGroups())
-
 	img.KernelOptionsAppend = []string{
 		"rw",
 		// TODO: Drop this as we expect kargs to come from the container image,
@@ -87,8 +85,6 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 		"console=tty0",
 		"console=ttyS0",
 	}
-
-	img.SysrootReadOnly = true
 
 	switch c.Architecture {
 	case arch.ARCH_X86_64:

--- a/bib/cmd/bootc-image-builder/main_test.go
+++ b/bib/cmd/bootc-image-builder/main_test.go
@@ -67,7 +67,6 @@ func getBaseConfig() *main.ManifestConfig {
 
 func getUserConfig() *main.ManifestConfig {
 	// add a user
-	pass := "super-secret-password-42"
 	key := "ssh-ed25519 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 	return &main.ManifestConfig{
 		Imgref:    "testuser",
@@ -77,9 +76,8 @@ func getUserConfig() *main.ManifestConfig {
 				Customizations: &blueprint.Customizations{
 					User: []blueprint.UserCustomization{
 						{
-							Name:     "tester",
-							Password: &pass,
-							Key:      &key,
+							Name: "root",
+							Key:  &key,
 						},
 					},
 				},
@@ -173,7 +171,7 @@ func TestManifestSerialization(t *testing.T) {
 		"build": {
 			containerSpec,
 		},
-		"ostree-deployment": {
+		"image": {
 			containerSpec,
 		},
 	}
@@ -230,15 +228,12 @@ func TestManifestSerialization(t *testing.T) {
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
-				"ostree-deployment": {
-					"org.osbuild.ostree.deploy.container",
+				"image": {
+					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
 			nexpStages: map[string][]string{
 				"build": {"org.osbuild.rpm"},
-				"ostree-deployment": {
-					"org.osbuild.users",
-				},
 			},
 		},
 		"raw-base": {
@@ -247,15 +242,12 @@ func TestManifestSerialization(t *testing.T) {
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
-				"ostree-deployment": {
-					"org.osbuild.ostree.deploy.container",
+				"image": {
+					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
 			nexpStages: map[string][]string{
 				"build": {"org.osbuild.rpm"},
-				"ostree-deployment": {
-					"org.osbuild.users",
-				},
 			},
 		},
 		"qcow2-base": {
@@ -264,15 +256,12 @@ func TestManifestSerialization(t *testing.T) {
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
-				"ostree-deployment": {
-					"org.osbuild.ostree.deploy.container",
+				"image": {
+					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
 			nexpStages: map[string][]string{
 				"build": {"org.osbuild.rpm"},
-				"ostree-deployment": {
-					"org.osbuild.users",
-				},
 			},
 		},
 		"ami-user": {
@@ -281,9 +270,8 @@ func TestManifestSerialization(t *testing.T) {
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
-				"ostree-deployment": {
-					"org.osbuild.users",
-					"org.osbuild.ostree.deploy.container",
+				"image": {
+					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
 			nexpStages: map[string][]string{
@@ -296,9 +284,8 @@ func TestManifestSerialization(t *testing.T) {
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
-				"ostree-deployment": {
-					"org.osbuild.users", // user creation stage when we add users
-					"org.osbuild.ostree.deploy.container",
+				"image": {
+					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
 			nexpStages: map[string][]string{
@@ -311,9 +298,8 @@ func TestManifestSerialization(t *testing.T) {
 			containers: diskContainers,
 			expStages: map[string][]string{
 				"build": {"org.osbuild.container-deploy"},
-				"ostree-deployment": {
-					"org.osbuild.users", // user creation stage when we add users
-					"org.osbuild.ostree.deploy.container",
+				"image": {
+					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
 			nexpStages: map[string][]string{
@@ -343,20 +329,23 @@ func TestManifestSerialization(t *testing.T) {
 			packages:   isoPackages,
 			err:        "missing ostree, container, or ospipeline parameters in ISO tree pipeline",
 		},
+		// the errors here when the containers are misisng are
+		// confusing, we should probably not test for them at
+		// this level
 		"ami-nocontainer": {
 			config:     userConfig,
 			imageTypes: []string{"ami"},
-			err:        "pipeline ostree-deployment requires exactly one ostree commit or one container (have commits: []; containers: [])",
+			err:        "serialization not started",
 		},
 		"raw-nocontainer": {
 			config:     userConfig,
 			imageTypes: []string{"raw"},
-			err:        "pipeline ostree-deployment requires exactly one ostree commit or one container (have commits: []; containers: [])",
+			err:        "serialization not started",
 		},
 		"qcow2-nocontainer": {
 			config:     userConfig,
 			imageTypes: []string{"qcow2"},
-			err:        "pipeline ostree-deployment requires exactly one ostree commit or one container (have commits: []; containers: [])",
+			err:        "serialization not started",
 		},
 	}
 

--- a/bib/cmd/bootc-image-builder/main_test.go
+++ b/bib/cmd/bootc-image-builder/main_test.go
@@ -52,13 +52,13 @@ func TestCanChownInPathCannotChange(t *testing.T) {
 }
 
 type manifestTestCase struct {
-	config     *main.ManifestConfig
-	imageTypes []string
-	packages   map[string][]rpmmd.PackageSpec
-	containers map[string][]container.Spec
-	expStages  map[string][]string
-	nexpStages map[string][]string
-	err        interface{}
+	config            *main.ManifestConfig
+	imageTypes        []string
+	packages          map[string][]rpmmd.PackageSpec
+	containers        map[string][]container.Spec
+	expStages         map[string][]string
+	notExpectedStages map[string][]string
+	err               interface{}
 }
 
 func getBaseConfig() *main.ManifestConfig {
@@ -232,7 +232,7 @@ func TestManifestSerialization(t *testing.T) {
 					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
-			nexpStages: map[string][]string{
+			notExpectedStages: map[string][]string{
 				"build": {"org.osbuild.rpm"},
 			},
 		},
@@ -246,7 +246,7 @@ func TestManifestSerialization(t *testing.T) {
 					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
-			nexpStages: map[string][]string{
+			notExpectedStages: map[string][]string{
 				"build": {"org.osbuild.rpm"},
 			},
 		},
@@ -260,7 +260,7 @@ func TestManifestSerialization(t *testing.T) {
 					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
-			nexpStages: map[string][]string{
+			notExpectedStages: map[string][]string{
 				"build": {"org.osbuild.rpm"},
 			},
 		},
@@ -274,7 +274,7 @@ func TestManifestSerialization(t *testing.T) {
 					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
-			nexpStages: map[string][]string{
+			notExpectedStages: map[string][]string{
 				"build": {"org.osbuild.rpm"},
 			},
 		},
@@ -288,7 +288,7 @@ func TestManifestSerialization(t *testing.T) {
 					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
-			nexpStages: map[string][]string{
+			notExpectedStages: map[string][]string{
 				"build": {"org.osbuild.rpm"},
 			},
 		},
@@ -302,7 +302,7 @@ func TestManifestSerialization(t *testing.T) {
 					"org.osbuild.bootc.install-to-filesystem",
 				},
 			},
-			nexpStages: map[string][]string{
+			notExpectedStages: map[string][]string{
 				"build": {"org.osbuild.rpm"},
 			},
 		},
@@ -368,7 +368,7 @@ func TestManifestSerialization(t *testing.T) {
 			} else {
 				manifestJson, err := mf.Serialize(tc.packages, tc.containers, nil)
 				assert.NoError(err)
-				assert.NoError(checkStages(manifestJson, tc.expStages, tc.nexpStages))
+				assert.NoError(checkStages(manifestJson, tc.expStages, tc.notExpectedStages))
 			}
 		})
 	}

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/google/uuid v1.6.0
 	github.com/moby/sys/mountinfo v0.7.1
-	github.com/osbuild/images v0.50.0
+	github.com/osbuild/images v0.51.1-0.20240326154530-58ef1aea0410
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -279,6 +279,8 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/osbuild/images v0.50.0 h1:UONHoTONdgOLBZ6ZNXKLsnMefgq3bccgxBvmlRyEhbk=
 github.com/osbuild/images v0.50.0/go.mod h1:eM/J8+hEUH0jrwcy3DtE6SDg+bRMWFZIf5d+YDyhoDY=
+github.com/osbuild/images v0.51.1-0.20240326154530-58ef1aea0410 h1:93/m6O0nH1sU4TY2Dlh6lFfaS8gHQP8hAb3HnTrCS3E=
+github.com/osbuild/images v0.51.1-0.20240326154530-58ef1aea0410/go.mod h1:eM/J8+hEUH0jrwcy3DtE6SDg+bRMWFZIf5d+YDyhoDY=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import pytest
 
@@ -27,3 +28,41 @@ def test_bib_chown_opts(tmp_path, build_fake_container, chown_opt, expected_uid_
         assert p.exists()
         assert p.stat().st_uid == expected_uid_gid[0]
         assert p.stat().st_gid == expected_uid_gid[1]
+
+
+def test_bib_config_errors_for_default(tmp_path, build_fake_container):
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+
+    ret = subprocess.run([
+        "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
+        "-v", f"{output_path}:/output",
+        build_fake_container,
+        "--iso-config", "/some/random/config",
+        "quay.io/centos-bootc/centos-bootc:stream9",
+    ], check=False, encoding="utf8", stdout=sys.stdout, stderr=subprocess.PIPE)
+    assert ret.returncode != 0
+    assert "the --iso-config switch is only supported for ISO images" in ret.stderr
+
+
+def test_bib_iso_config_is_parsed(tmp_path, build_fake_container):
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+
+    # check that config.json is tried to be loaded
+    (tmp_path / "config.json").write_text("invalid-json", encoding="utf8")
+    ret = subprocess.run([
+        "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
+        "-v", f"{output_path}:/output",
+        "-v", f"{tmp_path}/config.json:/config.json",
+        build_fake_container,
+        "--iso-config", "/config.json",
+        "--type", "anaconda-iso",
+        "quay.io/centos-bootc/centos-bootc:stream9",
+    ], check=False, encoding="utf8", stdout=sys.stdout, stderr=subprocess.PIPE)
+    assert ret.returncode != 0
+    assert "cannot load config: invalid character" in ret.stderr

--- a/test/vm.py
+++ b/test/vm.py
@@ -1,5 +1,6 @@
 import abc
 import os
+import paramiko
 import pathlib
 import platform
 import subprocess
@@ -43,7 +44,7 @@ class VM(abc.ABC):
         Stop the VM and clean up any resources that were created when setting up and starting the machine.
         """
 
-    def run(self, cmd, user, password):
+    def run(self, cmd, user, keyfile):
         """
         Run a command on the VM via SSH using the provided credentials.
         """
@@ -51,8 +52,11 @@ class VM(abc.ABC):
             self.start()
         client = SSHClient()
         client.set_missing_host_key_policy(AutoAddPolicy)
+        # workaround, see https://github.com/paramiko/paramiko/issues/2048
+        pkey = paramiko.RSAKey.from_private_key_file(keyfile)
         client.connect(
-            self._address, self._ssh_port, user, password,
+            self._address, self._ssh_port,
+            user, pkey=pkey,
             allow_agent=False, look_for_keys=False)
         chan = client.get_transport().open_session()
         chan.get_pty()


### PR DESCRIPTION
This PR switches bib to the version of the images library from PR https://github.com/osbuild/images/pull/462 that defaults to use `bootc install to-filesystem`. Because some things will work differently in this model this PR touches a lot of things:
1. It removes customizations and the `-config` option as we currently have only very limited support for them in the new world (for the iso the customizations are still supported via --iso-config)
2. It updates the README to have a new default example so that users can still play around and login into a generated image (should probably add an example for --iso-config there now though)
3. switches the testing to use the bootc -root-authorized-keys support instead of the previous passwd based testing

This is ready now but I expect test failures until https://github.com/containers/bootc/pull/407 is available in our tested containers.