### PR TITLE
Update to go 1.20

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/bootc-image-builder/bib
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.51.5


### PR DESCRIPTION
I think pinning on 1.19 is holding some dependency updates back, and 1.20 is in rhel9 now.