### PR TITLE
bib: detect missing qemu-user early

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,7 @@ FROM registry.fedoraproject.org/fedora:39
 COPY ./group_osbuild-osbuild-fedora-39.repo /etc/yum.repos.d/
 COPY ./package-requires.txt .
 RUN grep -vE '^#' package-requires.txt | xargs dnf install -y && rm -f package-requires.txt && dnf clean all
-COPY --from=builder /build/bin/bootc-image-builder /usr/bin/bootc-image-builder
+COPY --from=builder /build/bin/* /usr/bin/
 COPY entrypoint.sh /
 COPY bib/data /usr/share/bootc-image-builder
 

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -361,7 +361,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	targetArch, _ := cmd.Flags().GetString("target-arch")
 
 	logrus.Debug("Validating environment")
-	if err := setup.Validate(); err != nil {
+	if err := setup.Validate(targetArch); err != nil {
 		return fmt.Errorf("cannot validate the setup: %w", err)
 	}
 	logrus.Debug("Ensuring environment setup")

--- a/bib/cmd/cross-arch/canary.go
+++ b/bib/cmd/cross-arch/canary.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	println("ok")
+}

--- a/bib/internal/setup/export_test.go
+++ b/bib/internal/setup/export_test.go
@@ -1,0 +1,3 @@
+package setup
+
+var ValidateCanRunTargetArch = validateCanRunTargetArch

--- a/bib/internal/setup/setup_test.go
+++ b/bib/internal/setup/setup_test.go
@@ -1,0 +1,63 @@
+package setup_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/bootc-image-builder/bib/internal/setup"
+)
+
+func TestValidateCanRunTargetArchTrivial(t *testing.T) {
+	for _, arch := range []string{runtime.GOARCH, ""} {
+		err := setup.ValidateCanRunTargetArch(arch)
+		assert.NoError(t, err)
+	}
+}
+
+func TestValidateCanRunTargetArchUnsupportedCanary(t *testing.T) {
+	var logbuf bytes.Buffer
+	logrus.SetOutput(&logbuf)
+
+	err := setup.ValidateCanRunTargetArch("unsupported-arch")
+	assert.NoError(t, err)
+	assert.Contains(t, logbuf.String(), `level=warning msg="cannot check architecture support for unsupported-arch: no canary binary found"`)
+}
+
+func makeFakeCanary(t *testing.T, content string) {
+	tmpdir := t.TempDir()
+	t.Setenv("PATH", os.Getenv("PATH")+":"+tmpdir)
+	err := os.WriteFile(filepath.Join(tmpdir, "bib-canary-fakearch"), []byte(content), 0755)
+	assert.NoError(t, err)
+}
+
+func TestValidateCanRunTargetArchHappy(t *testing.T) {
+	var logbuf bytes.Buffer
+	logrus.SetOutput(&logbuf)
+
+	makeFakeCanary(t, "#!/bin/sh\necho ok")
+
+	err := setup.ValidateCanRunTargetArch("fakearch")
+	assert.NoError(t, err)
+	assert.Equal(t, "", logbuf.String())
+}
+
+func TestValidateCanRunTargetArchExecFormatError(t *testing.T) {
+	makeFakeCanary(t, "")
+
+	err := setup.ValidateCanRunTargetArch("fakearch")
+	assert.ErrorContains(t, err, `cannot run canary binary for "fakearch", do you have 'qemu-user-static' installed?`)
+	assert.ErrorContains(t, err, `: exec format error`)
+}
+
+func TestValidateCanRunTargetArchUnexpectedOutput(t *testing.T) {
+	makeFakeCanary(t, "#!/bin/sh\necho xxx")
+
+	err := setup.ValidateCanRunTargetArch("fakearch")
+	assert.ErrorContains(t, err, `internal error: unexpected output`)
+}

--- a/build.sh
+++ b/build.sh
@@ -9,3 +9,17 @@ CONTAINERS_STORAGE_THIN_TAGS="containers_image_openpgp exclude_graphdriver_btrfs
 cd bib
 set -x
 go build -tags "${CONTAINERS_STORAGE_THIN_TAGS}" -o ../bin/bootc-image-builder ./cmd/bootc-image-builder
+
+# expand the list as we support more architectures
+for arch in amd64 arm64; do
+    if [ "$arch" = "$(go env GOARCH)" ]; then
+	continue
+    fi
+
+    # what is slightly sad is that this generates a 1MB file. Fedora does
+    # not have a cross gcc that can cross build userspace otherwise something
+    # like: `void _start() { syscall(SYS_exit() }` would work with
+    # `gcc -static -static-libgcc -nostartfiles -nostdlib -l` and give us a 10k
+    # cross platform binary. Or maybe no-std rust (thanks Colin)?
+    GOARCH="$arch" go build -ldflags="-s -w" -o ../bin/bib-canary-"$arch" ./cmd/cross-arch/
+done


### PR DESCRIPTION
This commit checks early if cross architecture building support via `qemu-user-static` (or similar tooling) is missing and errors in a more user friendly way.

[draft as it needs some proper tests still]