### PR TITLE
Automatically pick up `/config.json` if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ sudo podman run \
     -v $(pwd)/output:/output \
     quay.io/centos-bootc/bootc-image-builder:latest \
     --type qcow2 \
-    --config /config.json \
     quay.io/centos-bootc/fedora-bootc:eln
 ```
 
@@ -134,7 +133,7 @@ Usage:
 
 Flags:
       --chown string           chown the ouput directory to match the specified UID:GID
-      --config string          build config file
+      --config string          build config file (default: /config.json if present)
       --tls-verify             require HTTPS and verify certificates when contacting registries (default true)
       --type string            image type to build [qcow2, ami] (default "qcow2")
       --target-arch string     architecture to build image for (default is the native architecture)

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -237,6 +237,7 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
             "--privileged",
             "--security-opt", "label=type:unconfined_t",
             "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
+            "-v", f"{config_json_path}:/config.json:ro",
             "-v", f"{output_path}:/output",
             "-v", "/store",  # share the cache between builds
         ]
@@ -249,7 +250,6 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
             *creds_args,
             build_container,
             container_ref,
-            "--config", "/output/config.json",
             *types_arg,
             *upload_args,
             *target_arch_args,


### PR DESCRIPTION
When passing a config, it's an ergonomic hit to need to provide it on *both* the `podman run` invocation *and* the arguments to the binary.

Change things so that we automatically pick up `/config.json` if it exists in the container.  This way the user only needs to give the podman argument.