### PR TITLE
document that `customizations.kernel.append` exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,21 @@ Example:
 }
 ```
 
+### Kernel Arguments (`kernel`, mapping)
+
+```json
+{
+  "blueprint": {
+    "customizations": {
+      "kernel": {
+        "append": "mitigations=auto,nosmt"
+      }
+    }
+  }
+}
+
+```
+
 ## Building
 
 To build the container locally you can run

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -191,6 +191,9 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
                         "groups": ["wheel"],
                     },
                 ],
+                "kernel": {
+                    "append": "user.sometestkarg=sometestvalue"
+                }
             },
         },
     }


### PR DESCRIPTION
I noticed this was wired up in the code, but undocumented and untested.

There are valid use cases for machine-specific kernel arguments, so let's support that here.

(What's the best place to verify that the kargs show up in the test
 VMs? )