### PR TITLE
pin osbuild to a version before the depsolver changes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,9 +16,7 @@ FROM registry.fedoraproject.org/fedora:39
 # - https://github.com/osbuild/osbuild/pull/1468
 COPY ./group_osbuild-osbuild-fedora-39.repo /etc/yum.repos.d/
 COPY ./package-requires.txt .
-RUN grep -vE '^#' package-requires.txt | xargs dnf install -y && rm -f package-requires.txt && \
-    dnf -y upgrade https://kojipkgs.fedoraproject.org//packages/rpm-ostree/2024.4/3.fc39/$(arch)/rpm-ostree-{,libs-}2024.4-3.fc39.$(arch).rpm \
-&& dnf clean all
+RUN grep -vE '^#' package-requires.txt | xargs dnf install -y && rm -f package-requires.txt && dnf clean all
 COPY --from=builder /build/bin/bootc-image-builder /usr/bin/bootc-image-builder
 COPY entrypoint.sh /
 

--- a/package-requires.txt
+++ b/package-requires.txt
@@ -2,7 +2,7 @@
 # from the Containerfile by default, using leading '#' as comments.
 
 # This project uses osbuild
-osbuild osbuild-ostree osbuild-depsolve-dnf
+osbuild-115-1.20240410231807828982.main.2.gdbe70396.fc39 osbuild-ostree-115-1.20240410231807828982.main.2.gdbe70396.fc39 osbuild-depsolve-dnf-115-1.20240410231807828982.main.2.gdbe70396.fc39
 
 # We mount container images internally
 podman


### PR DESCRIPTION
[pin osbuild to a version before the depsolver changes](https://github.com/osbuild/bootc-image-builder/commit/6fddc67a7b308f440e02b288c9bbe8bd001071c0)

https://github.com/osbuild/osbuild/pull/1674 broke the depsolver API.
This is already fixed in images, but bumping images in bib requires
more changes, and we want to unblock everything ASAP, so let's just
pin osbuild to get the old depsolver once again.

Fixes #352

---

[Containerfile: remove outdated rpm-ostree upgrade](https://github.com/osbuild/bootc-image-builder/commit/4796bc0988dcbc15bd0d71deab0f7839f57e770b)

I'm getting the following error, so this is no longer needed:

The same or higher version of rpm-ostree is already installed, cannot update it.