### PR TITLE
main: decorate more errors with context and avoid panics

### DIFF
--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -89,7 +89,7 @@ def test_manifest_local_checks_containers_storage_errors(build_container):
         build_container,
     ], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf8")
     assert res.returncode == 1
-    err = 'Error: local storage not working, did you forget -v /var/lib/containers/storage:/var/lib/containers/storage?'
+    err = 'local storage not working, did you forget -v /var/lib/containers/storage:/var/lib/containers/storage?'
     assert err in res.stderr
 
 


### PR DESCRIPTION
We recently had a bugreport where a panic had very little error context:
```
Generating manifest manifest-iso.json
panic: exec: no command
```
this prompted this commit so that:
a) we do add more context to our errors
b) avoid panicing when we can also return errors

This may lead to some stuttering `cannot do foo: cannot generate foo: cannot make foo a thing` but we can tweak and more context right now is probably better than less (ideally we would have tests that cover this and help us figure out how to fine tune it).