### PR TITLE
test: test root user setup

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -124,7 +124,7 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
 
     username = "test"
     password = "password"
-    kargs = "user.sometestkarg=sometestvalue"
+    kargs = "systemd.journald.forward_to_console=1"
 
     # params can be long and the qmp socket (that has a limit of 100ish
     # AF_UNIX) is derived from the path


### PR DESCRIPTION
A continuation of https://github.com/osbuild/bootc-image-builder/pull/357 - the root user is used to do a `bootc status` inside the booted container to ensure the setup is correct. This is nicer then the previous `sudo` approach and it has the added benefit of testing the root user creation/setup during the build too.