### PR TITLE
bib: ignore --target-arch if it is the same as the running arch

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -238,7 +238,7 @@ func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, error) {
 	tlsVerify, _ := cmd.Flags().GetBool("tls-verify")
 	localStorage, _ := cmd.Flags().GetBool("local")
 
-	if targetArch != "" {
+	if targetArch != "" && arch.FromString(targetArch) != arch.Current() {
 		// TODO: detect if binfmt_misc for target arch is
 		// available, e.g. by mounting the binfmt_misc fs into
 		// the container and inspects the files or by

--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -44,6 +44,10 @@ def build_fake_container_fixture(tmpdir_factory, build_container):
     fake_osbuild_path.write_text(textwrap.dedent("""\
     #!/bin/sh -e
 
+    # injest generated manifest from the images library, if we do not
+    # do this images may fail with "broken" pipe errors
+    cat -
+
     mkdir -p /output/qcow2
     echo "fake-disk.qcow2" > /output/qcow2/disk.qcow2
 

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -1,3 +1,4 @@
+import platform
 import subprocess
 
 import pytest
@@ -27,3 +28,31 @@ def test_bib_chown_opts(tmp_path, build_fake_container, chown_opt, expected_uid_
         assert p.exists()
         assert p.stat().st_uid == expected_uid_gid[0]
         assert p.stat().st_gid == expected_uid_gid[1]
+
+
+@pytest.mark.parametrize("target_arch_opt, expected_err", [
+    ([], ""),
+    (["--target-arch=amd64"], ""),
+    (["--target-arch=x86_64"], ""),
+    (["--target-arch=arm64"], "cannot build iso for different target arches yet"),
+])
+@pytest.mark.skipif(platform.uname().machine != "x86_64", reason="cross build test only runs on x86")
+def test_opts_arch_is_same_arch_is_fine(tmp_path, build_fake_container, target_arch_opt, expected_err):
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+
+    res = subprocess.run([
+        "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
+        "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
+        "-v", f"{output_path}:/output",
+        build_fake_container,
+        "--type=iso",
+        "quay.io/centos-bootc/centos-bootc:stream9",
+    ] + target_arch_opt, check=False, capture_output=True, text=True)
+    if expected_err == "":
+        assert res.returncode == 0
+    else:
+        assert res.returncode != 0
+        assert expected_err in res.stderr


### PR DESCRIPTION
If the user passes `--target-arch` and it is the same as the current arch just ignore the option as this is the default behavior anyway.

This partly closes
https://github.com/osbuild/bootc-image-builder/issues/316