### PR TITLE
bib: run go unittest in GH actions and fix them

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   lint:
-    name: "⌨ Lint"
+    name: "⌨ Lint & unittests"
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.20
@@ -41,6 +41,9 @@ jobs:
           version: v1.55.2
           args: --timeout 5m0s
           working-directory: bib
+
+      - name: Run unit tests
+        run: (cd bib && go test -race  ./...)
 
   shellcheck:
     name: "🐚 Shellcheck"

--- a/bib/cmd/bootc-image-builder/main_test.go
+++ b/bib/cmd/bootc-image-builder/main_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	main "github.com/osbuild/bootc-image-builder/bib/cmd/bootc-image-builder"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/rpmmd"
+
+	main "github.com/osbuild/bootc-image-builder/bib/cmd/bootc-image-builder"
 )
 
 func TestCanChownInPathHappy(t *testing.T) {
@@ -62,7 +64,10 @@ type manifestTestCase struct {
 }
 
 func getBaseConfig() *main.ManifestConfig {
-	return &main.ManifestConfig{Imgref: "testempty"}
+	return &main.ManifestConfig{
+		Architecture: arch.ARCH_X86_64,
+		Imgref:       "testempty",
+	}
 }
 
 func getUserConfig() *main.ManifestConfig {
@@ -70,8 +75,9 @@ func getUserConfig() *main.ManifestConfig {
 	pass := "super-secret-password-42"
 	key := "ssh-ed25519 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 	return &main.ManifestConfig{
-		Imgref:    "testuser",
-		BuildType: 0,
+		Architecture: arch.ARCH_X86_64,
+		Imgref:       "testuser",
+		BuildType:    0,
 		Config: &main.BuildConfig{
 			Blueprint: &blueprint.Blueprint{
 				Customizations: &blueprint.Customizations{


### PR DESCRIPTION
Previously the `0` value of the images `arch.Architecture` iota
was of type `ARCH_AARCH64`. However with
https://github.com/osbuild/images/commit/05355326188f3d2ad49003784d681524eba466ce
this is no longer the case an the zero type is now a proper
`UNSET` type. And the tests now fail because they did not set
the architecture.

This PR fixes this by setting the architecture and also adds them to the GH action