### PR TITLE
bib: tweak podman pull/getContainerSize

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -143,9 +143,8 @@ func makeManifest(c *ManifestConfig, cacheRoot string) (manifest.OSBuildManifest
 	// to using containers storage in all code paths happened.
 	// We might want to change this behaviour in the future to match podman.
 	if !c.Local {
-		pullCmd := exec.Command("podman", "pull", "--arch", c.Architecture.String(), c.Imgref)
-		if err := pullCmd.Run(); err != nil {
-			return nil, fmt.Errorf("failed to pull container image: %w", err)
+		if output, err := exec.Command("podman", "pull", "--arch", c.Architecture.String(), c.Imgref).CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("failed to pull container image: %w\n%s", err, output)
 		}
 	}
 	cntSize, err := getContainerSize(c.Imgref)

--- a/bib/internal/util/util.go
+++ b/bib/internal/util/util.go
@@ -26,3 +26,12 @@ func RunCmdSync(cmdName string, args ...string) error {
 	}
 	return nil
 }
+
+// OutputErr takes an error from exec.Command().Output() and tries
+// generate an error with stderr details
+func OutputErr(err error) error {
+	if err, ok := err.(*exec.ExitError); ok {
+		return fmt.Errorf("%w, stderr:\n%s", err, err.Stderr)
+	}
+	return err
+}

--- a/bib/internal/util/util_test.go
+++ b/bib/internal/util/util_test.go
@@ -1,0 +1,21 @@
+package util_test
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/bootc-image-builder/bib/internal/util"
+)
+
+func TestOutputErrPassthrough(t *testing.T) {
+	err := fmt.Errorf("boom")
+	assert.Equal(t, util.OutputErr(err), err)
+}
+
+func TestOutputErrExecError(t *testing.T) {
+	_, err := exec.Command("bash", "-c", ">&2 echo some-stderr; exit 1").Output()
+	assert.Equal(t, "exit status 1, stderr:\nsome-stderr\n", util.OutputErr(err).Error())
+}


### PR DESCRIPTION
Subject: [PATCH] bib: simplify getContainerSize()

The getContainerSize() was not using some of the modern go helpers.
So let's use `exec.Command().Output()` and introduce a new
`util.OutputErr()` helper that will be able to also show stderr to
the user if the Output() call returns an error.

---

Subject: [PATCH] bib: show error details from podman if `podman pull` fails

Right now if `podman pull` fails no error output from podman is
visible to the user. This commit tweaks that so that the output
is part of the error.
