### PR TITLE
image: enable `org.fedoraproject.Anaconda.Modules.Users` if needed

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -285,6 +285,12 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
+	// XXX: this should really be done by images, the consumer should not
+	// need to know these details. so once images is fixed drop it here
+	// again.
+	if len(img.Users) > 0 || len(img.Groups) > 0 {
+		img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")
+	}
 
 	switch c.Architecture {
 	case arch.ARCH_X86_64:


### PR DESCRIPTION
It turns out that on centos9 users are not added when specified in kickstart files. This commit should fix this and users are added. I did a manual validation but this will be part of the test for https://github.com/osbuild/bootc-image-builder/pull/338 (the test in 338 still not works, it seems the machine has no network(?) but I guess baby steps :)

P.S. No test as this really needs to be in images and I will add a test there (and then this needs reverting).

