### PR TITLE
workflow,tests: use `/var/tmp/osbuild-test-store` and cache that

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,14 @@ jobs:
         # on GH runners /mnt has 70G free space, use that for our container
         # storage
         sudo mkdir -p /mnt/var/lib/containers
-        sudo mount -o bind /mnt/var/lib/containers /var/lib/containers 
+        sudo mount -o bind /mnt/var/lib/containers /var/lib/containers
+    - run: |
+        mkdir -p /var/tmp/osbuild-test-store
+    - name: Cache osbuild env
+      uses: actions/cache@v4
+      with:
+        path: /var/tmp/osbuild-test-store
+        key: no-key-needed-here
     - name: Run tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -243,7 +243,7 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
             "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
             "-v", f"{config_json_path}:/config.json:ro",
             "-v", f"{output_path}:/output",
-            "-v", "/store",  # share the cache between builds
+            "-v", "/var/tmp/osbuild-test-store:/store",  # share the cache between builds
         ]
 
         # we need to mount the host's container store


### PR DESCRIPTION
This hopefully speeds up the tests, especially the iso ones.

In my local testing the different between first run (no shared cache) and second run (cache populated):
```
$ sudo pytest  -s -vv  './test/test_build.py::test_iso_installs[quay.io/centos-bootc/centos-bootc:stream9,anaconda-iso]'

no cache
=================== 1 passed, 1 warning in 616.89s (0:10:16) ===================


second run with populated cache
=================== 1 passed, 1 warning in 393.41s (0:06:33) ===================

```