### PR TITLE
bib: when "podman rmi" fails, print debug and try harder

### DIFF
--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -17,7 +17,12 @@ def make_container(container_path):
         "-t", container_tag,
         container_path], encoding="utf8")
     yield container_tag
-    subprocess.check_call(["podman", "rmi", container_tag])
+    try:
+        subprocess.check_call(["podman", "rmi", container_tag])
+    except subprocess.CalledProcessError:
+        # debug
+        subprocess.check_call(["podman", "ps", "--all", "--storage"])
+        subprocess.check_call(["podman", "rmi", "--force", container_tag])
 
 
 @pytest.fixture(name="build_container", scope="session")


### PR DESCRIPTION
This works around the issue seen in the tests:
```
________ test_manifest_disksize[quay.io/centos-bootc/fedora-bootc:eln] _________
tmp_path = PosixPath('/mnt/var/tmp/bib-tests/test_manifest_disksize_quay_io0')
build_container = 'bootc-image-builder-test'
testcase_ref = 'quay.io/centos-bootc/fedora-bootc:eln'
    @pytest.mark.parametrize("testcase_ref", gen_testcases("manifest"))
    def test_manifest_disksize(tmp_path, build_container, testcase_ref):
        # create derrived container with 6G silly file to ensure that
        # bib doubles the size to 12G+
        cntf_path = tmp_path / "Containerfile"
        cntf_path.write_text(textwrap.dedent(f"""\n
        FROM {testcase_ref}
        RUN truncate -s 2G /big-file1
        RUN truncate -s 2G /big-file2
        RUN truncate -s 2G /big-file3
        """), encoding="utf8")
    
        print(f"building big size container from {testcase_ref}")
>       with make_container(tmp_path) as container_tag:
test/test_manifest.py:63: 
...
Error: image used by e49a35b2b7cd39a02736ceebe5ec518a43eaf4cc4b92799e97f8b4cb5cda4545: image is in use by a container: consider listing external containers and force-removing image
```
as seen in e.g. https://github.com/osbuild/bootc-image-builder/actions/runs/8785521772/job/24106238490?pr=338

See also https://github.com/containers/podman/issues/7889#issuecomment-702732084