### PR TITLE
test: enable iso installer tests for both centos/fedora

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -413,7 +413,6 @@ def test_image_build_without_se_linux_denials(image_type):
         f"denials in log {image_type.journal_output}"
 
 
-@pytest.mark.skip(reason="see https://github.com/osbuild/bootc-image-builder/issues/233")
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
 @pytest.mark.parametrize("image_type", gen_testcases("anaconda-iso"), indirect=["image_type"])
 def test_iso_installs(image_type):

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -38,11 +38,9 @@ def gen_testcases(what):
         return [cnt + ",ami" for cnt in CONTAINERS_TO_TEST.values()]
     elif what == "anaconda-iso":
         test_cases = []
-        # only fedora right now, centos iso installer is broken right now:
-        # https://github.com/osbuild/bootc-image-builder/issues/157
-        cnt = CONTAINERS_TO_TEST["fedora"]
-        for img_type in INSTALLER_IMAGE_TYPES:
-            test_cases.append(f"{cnt},{img_type}")
+        for cnt in CONTAINERS_TO_TEST.values():
+            for img_type in INSTALLER_IMAGE_TYPES:
+                test_cases.append(f"{cnt},{img_type}")
         return test_cases
     elif what == "qemu-boot":
         test_cases = []


### PR DESCRIPTION
Now that we can inspect the image enable the iso installer tests again.