### PR TITLE
buildconfig: make buildconfig blueprint compatible and  support legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,14 +276,14 @@ The following volumes can be mounted inside the container:
 
 ## 📝 Build config
 
-A build config is a Toml (or JSON) file with customizations for the resulting image. A path to the file is passed via  the `--config` argument. The customizations are specified under a `blueprint.customizations` object.
+A build config is a Toml (or JSON) file with customizations for the resulting image. A path to the file is passed via  the `--config` argument. The customizations are specified under a `customizations` object.
 
 As an example, let's show how you can add a user to the image:
 
 Firstly create a file `./config.toml` and put the following content into it:
 
 ```json
-[[blueprint.customizations.user]]
+[[customizations.user]]
 name = "alice"
 password = "bob"
 key = "ssh-rsa AAA ... user@email.com"
@@ -339,11 +339,9 @@ Example:
 
 ```json
 {
-  "blueprint": {
-    "customizations": {
-      "kernel": {
-        "append": "mitigations=auto,nosmt"
-      }
+  "customizations": {
+    "kernel": {
+      "append": "mitigations=auto,nosmt"
     }
   }
 }

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -84,8 +84,8 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 	}
 
 	var customizations *blueprint.Customizations
-	if c.Config != nil && c.Config.Blueprint != nil {
-		customizations = c.Config.Blueprint.Customizations
+	if c.Config != nil {
+		customizations = c.Config.Customizations
 	}
 
 	img := image.NewBootcDiskImage(containerSource)
@@ -198,8 +198,8 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	img.ISOLabel = fmt.Sprintf("Container-Installer-%s", c.Architecture)
 
 	var customizations *blueprint.Customizations
-	if c.Config != nil && c.Config.Blueprint != nil {
-		customizations = c.Config.Blueprint.Customizations
+	if c.Config != nil {
+		customizations = c.Config.Customizations
 	}
 
 	img.Users = users.UsersFromBP(customizations.GetUsers())

--- a/bib/cmd/bootc-image-builder/main_test.go
+++ b/bib/cmd/bootc-image-builder/main_test.go
@@ -93,14 +93,12 @@ func getUserConfig() *main.ManifestConfig {
 		Imgref:       "testuser",
 		BuildType:    0,
 		Config: &buildconfig.BuildConfig{
-			Blueprint: &blueprint.Blueprint{
-				Customizations: &blueprint.Customizations{
-					User: []blueprint.UserCustomization{
-						{
-							Name:     "tester",
-							Password: &pass,
-							Key:      &key,
-						},
+			Customizations: &blueprint.Customizations{
+				User: []blueprint.UserCustomization{
+					{
+						Name:     "tester",
+						Password: &pass,
+						Key:      &key,
 					},
 				},
 			},

--- a/bib/internal/buildconfig/config_test.go
+++ b/bib/internal/buildconfig/config_test.go
@@ -13,31 +13,27 @@ import (
 )
 
 var expectedBuildConfig = &buildconfig.BuildConfig{
-	Blueprint: &blueprint.Blueprint{
-		Customizations: &blueprint.Customizations{
-			User: []blueprint.UserCustomization{
-				{
-					Name: "alice",
-				},
+	Customizations: &blueprint.Customizations{
+		User: []blueprint.UserCustomization{
+			{
+				Name: "alice",
 			},
 		},
 	},
 }
 
 var fakeConfigJSON = `{
-  "blueprint": {
-    "customizations": {
-      "user": [
-        {
-          "name": "alice"
-        }
-     ]
-    }
+  "customizations": {
+    "user": [
+      {
+        "name": "alice"
+      }
+   ]
   }
 }`
 
 var fakeConfigToml = `
-[[blueprint.customizations.user]]
+[[customizations.user]]
 name = "alice"
 `
 
@@ -116,4 +112,23 @@ func TestReadUserConfigTwoConfigsError(t *testing.T) {
 
 	_, err := buildconfig.ReadWithFallback("")
 	assert.ErrorContains(t, err, `found "config.json" and also "config.toml", only a single one is supported`)
+}
+
+var fakeLegacyConfigJSON = `{
+  "blueprint": {
+    "customizations": {
+      "user": [
+        {
+          "name": "alice"
+        }
+     ]
+    }
+  }
+}`
+
+func TestReadLegacyJSONConfig(t *testing.T) {
+	fakeUserCnfPath := makeFakeConfig(t, "config.json", fakeLegacyConfigJSON)
+	cfg, err := buildconfig.ReadWithFallback(fakeUserCnfPath)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBuildConfig, cfg)
 }

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -190,19 +190,17 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
 
     # not all requested image types are available - build them
     cfg = {
-        "blueprint": {
-            "customizations": {
-                "user": [
-                    {
-                        "name": username,
-                        "password": password,
-                        "groups": ["wheel"],
-                    },
-                ],
-                "kernel": {
-                    "append": kargs,
-                }
-            },
+        "customizations": {
+            "user": [
+                {
+                    "name": username,
+                    "password": password,
+                    "groups": ["wheel"],
+                },
+            ],
+            "kernel": {
+                "append": kargs,
+            }
         },
     }
 

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -185,7 +185,7 @@ def test_manifest_user_customizations_toml(tmp_path, build_container):
 
     config_toml_path = tmp_path / "config.toml"
     config_toml_path.write_text(textwrap.dedent("""\
-    [[blueprint.customizations.user]]
+    [[customizations.user]]
     name = "alice"
     password = "$5$xx$aabbccddeeffgghhiijj"  # notsecret
     key = "ssh-rsa AAA ... user@email.com"


### PR DESCRIPTION
Make the buildconfig a blueprint but keep support for the legacy
format for now.

[build on top of https://github.com/osbuild/bootc-image-builder/pull/392]