### PR TITLE
bib: tweak target arch check

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/aws/aws-sdk-go v1.51.29
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/google/uuid v1.6.0
-	github.com/osbuild/images v0.56.0
+	github.com/osbuild/images v0.57.0
+	github.com/pelletier/go-toml v1.9.5
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -119,7 +120,7 @@ require (
 	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/mod v0.16.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
-	golang.org/x/sync v0.6.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.19.0 // indirect

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -281,8 +281,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/osbuild/images v0.56.0 h1:4/CMo4JgvPwD0lNi9HCExERc16RnPdXBQ9Ud6BRqAWg=
-github.com/osbuild/images v0.56.0/go.mod h1:N22xBt8wITxz8JfWZNY0FCl/tisaNqmGAz+GN9c7OEU=
+github.com/osbuild/images v0.57.0 h1:yClSMDdx0dB7Exrw5TrJ0SLoB+P+pCdoyZPc+G+p9o8=
+github.com/osbuild/images v0.57.0/go.mod h1:pq6g9uEoKZFxH/NnYeIo3L7/fhWL9HmveEIhGmK3sBQ=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
@@ -445,8 +445,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -117,7 +117,7 @@ def test_manifest_cross_arch_check(tmp_path, build_container):
     cntf_path = tmp_path / "Containerfile"
     cntf_path.write_text(textwrap.dedent("""\n
     # build for x86_64 only
-    FROM scratch
+    FROM quay.io/centos-bootc/centos-bootc:stream9
     """), encoding="utf8")
 
     with make_container(tmp_path, arch="x86_64") as container_tag:


### PR DESCRIPTION
In the more complex world of the manifest lists the native target arch check of bib does no longer work. Rely on the resolver to give us the right architecture.

Thanks to Charlie Drage for reporting the issue.

See also https://github.com/osbuild/images/pull/595 and https://github.com/osbuild/images/pull/635