### PR TITLE
Provide better error for containers without a rootfs default

### DIFF
--- a/bib/internal/container/container.go
+++ b/bib/internal/container/container.go
@@ -165,6 +165,9 @@ func (c *Container) RootfsType() (string, error) {
 	// bcachefs
 	supportedFS := []string{"ext4", "xfs"}
 
+	if fsType == "" {
+		return "", fmt.Errorf("container does not include a default root filesystem type")
+	}
 	if !slices.Contains(supportedFS, fsType) {
 		return "", fmt.Errorf("unsupported root filesystem type: %s, supported: %s", fsType, strings.Join(supportedFS, ", "))
 	}


### PR DESCRIPTION
For the generic Fedora base image the current plan is we won't include a default rootfs; that will be up to derived containers.

Output a slightly more useful error message in this case.