### PR TITLE
bib: add --roofs to be able to select the root fs type

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,14 @@ Flags:
 
 ### Detailed description of optional flags
 
-| Argument          | Description                                                         | Default Value |
-|-------------------|---------------------------------------------------------------------|:-------------:|
-| **--chown**       | chown the ouput directory to match the specified UID:GID            |       ❌      |
-| **--config**      | Path to a [build config](#-build-config)                            |       ❌      |
-| **--tls-verify**  | Require HTTPS and verify certificates when contacting registries    |    `true`     |
-| **--type**        | [Image type](#-image-types) to build                                |    `qcow2`    |
-| **--target-arch** | [Target arch](#-target-architecture) to build                       |       ❌      |
+| Argument          | Description                                                                                        | Default Value |
+|-------------------|----------------------------------------------------------------------------------------------------|:-------------:|
+| **--chown**       | chown the output directory to match the specified UID:GID                                          |       ❌      |
+| **--config**      | Path to a [build config](#-build-config)                                                           |       ❌      |
+| **--rootfs**      | Root filesystem type. Overrides the default from the source container. Supported values: ext4, xfs |
+| **--tls-verify**  | Require HTTPS and verify certificates when contacting registries                                   |    `true`     |
+| **--type**        | [Image type](#-image-types) to build                                                               |    `qcow2`    |
+| **--target-arch** | [Target arch](#-target-architecture) to build                                                      |       ❌      |
 
 The `--type` parameter can be given multiple times and multiple outputs will
 be produced.

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -169,6 +169,22 @@ def test_manifest_rootfs_respected(build_container, testcase_ref):
             pytest.fail(f"unknown container_ref {container_ref} please update test")
 
 
+def test_manifest_rootfs_override(build_container):
+    # no need to parameterize this test, --rootfs behaves same for all containers
+    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+
+    output = subprocess.check_output([
+        "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
+        f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest",\
+           "--rootfs", "ext4", "{container_ref}"]',
+        build_container,
+    ])
+    rootfs_type = find_rootfs_type_from(output)
+    assert rootfs_type == "ext4"
+
+
 def find_user_stage_from(manifest_str):
     manifest = json.loads(manifest_str)
     for pipl in manifest["pipelines"]:


### PR DESCRIPTION
Some container images don't have a default filesystem type. In this
case, a disk image build will fail. I'm a strong believer that we need
a one-line command to build a disk image. Thus, this commit adds
--rootfs which sets the root filesystem type if the container image
doesn't have one (or overrides it if it has one). By using --rootfs,
users will be able to run just one command to build an image once
again.

In the future, we will support custom partitioning via blueprints (or
different format). This means that we will need to figure out what takes
precedence. However, I suggest to cross that bridge when we get there.