### PR TITLE
tmt: fix testing farm test execution

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -30,7 +30,7 @@ execute:
     pip install --user -r test/requirements.txt
     echo "Run tests"
     pytest --force-aws-upload
-  duration: 2h
+  duration: 3h
 finish:
   how: shell
   script: df -h

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -2,13 +2,11 @@ summary: Run all tests inside a VM environment
 provision:
   how: virtual
   image: fedora:40
-  # 120 means 120GB, disk has to be specificed here, the format from:
-  #   https://tmt.readthedocs.io/en/stable/spec/hardware.html#disk
-  # does not work here or below under "hardware"
-  disk: 120
   hardware:
     virtualization:
       is-supported: true
+    disk:
+      - size: '>= 120 GB'
 prepare:
   how: install
   package:

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -26,7 +26,11 @@ prepare:
 execute:
   how: tmt
   script: |
+    echo "DEBUG: available diskspace"
+    df -h /
+    echo "Install test requirements"
     pip install --user -r test/requirements.txt
+    echo "Run tests"
     pytest --force-aws-upload
   duration: 2h
 finish:


### PR DESCRIPTION
Testing farm was broken for a while, it seems we got the wrong disksize for unkown reasons. This is now fixed by switching to a different disk request syntax.

Closes: https://github.com/osbuild/bootc-image-builder/issues/401