### PR TITLE
Replace `--local` with `--pull=[always,never,missing]` (HMS-3792)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ by adding a volume-mount for the local file as well as the `--config` flag to th
 The following command will create a QCOW2 disk image. First, create `./config.toml` as described above to configure user access.
 
 ```bash
-# Ensure the image is fetched
-sudo podman pull quay.io/centos-bootc/centos-bootc:stream9
 sudo podman run \
     --rm \
     -it \
@@ -43,11 +41,17 @@ sudo podman run \
     --security-opt label=type:unconfined_t \
     -v $(pwd)/config.toml:/config.toml \
     -v $(pwd)/output:/output \
+    -v /var/lib/containers/storage:/var/lib/containers/storage \
     quay.io/centos-bootc/bootc-image-builder:latest \
     --type qcow2 \
-    --local \
+    --pull=always \ # Ensure the image is fetched
     quay.io/centos-bootc/centos-bootc:stream9
 ```
+
+The `--pull` flag is based on the behaviour of `podman-build(1)` and has the following three options:
+- `--pull=always`, always pull the remote image
+- `--pull=missing`, only pull the image if it is not in local storage
+- `--pull=never`, don't pull the image (this is functionally the same as the deprecated `--local` flag)
 
 ### Running the resulting QCOW2 file on Linux (x86_64)
 

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -585,6 +585,7 @@ func run() error {
 	manifestCmd.Flags().Bool("local", false, "use a local container rather than a container from a registry")
 	manifestCmd.Flags().String("rootfs", "", "Root filesystem type. If not given, the default configured in the source container image is used.")
 	manifestCmd.Flags().String("pull", string(pullPolicyAlways), "pull policy ['always', 'never']")
+	_ = manifestCmd.Flags().MarkDeprecated("local", "use pull=never instead")
 
 	buildCmd.Flags().AddFlagSet(manifestCmd.Flags())
 	buildCmd.Flags().String("aws-ami-name", "", "name for the AMI in AWS (only for type=ami)")

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -256,7 +256,7 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
             *types_arg,
             *upload_args,
             *target_arch_args,
-            "--local" if local else "--local=false",
+            "--pull=never" if local else "--pull=always",
         ])
 
         # print the build command for easier tracing

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -70,7 +70,7 @@ def test_manifest_disksize(tmp_path, build_container, testcase_ref):
             # ensure local storage is here
             "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
             # need different entry point
-            f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--local", "localhost/{container_tag}"]',
+            f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--pull=never", "localhost/{container_tag}"]',
             build_container,
         ], encoding="utf8")
         # ensure disk size is bigger than the default 10G
@@ -86,7 +86,7 @@ def test_manifest_local_checks_containers_storage_errors(build_container):
         "podman", "run", "--rm",
         "--privileged",
         "--security-opt", "label=type:unconfined_t",
-        '--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--local", "arg-not-used"]',
+        '--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--pull=never", "arg-not-used"]',
         build_container,
     ], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf8")
     assert res.returncode == 1
@@ -107,7 +107,7 @@ def test_manifest_local_checks_containers_storage_works(tmp_path, build_containe
             "--privileged",
             "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
             "--security-opt", "label=type:unconfined_t",
-            f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--local", "localhost/{container_tag}"]',
+            f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--pull=never", "localhost/{container_tag}"]',
             build_container,
         ], check=True, encoding="utf8")
 
@@ -128,7 +128,7 @@ def test_manifest_cross_arch_check(tmp_path, build_container):
                 "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
                 "--security-opt", "label=type:unconfined_t",
                 f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest",\
-                   "--target-arch=aarch64", "--local", \
+                   "--target-arch=aarch64", "--pull=never", \
                    "localhost/{container_tag}"]',
                 build_container,
             ], check=True, capture_output=True, encoding="utf8")


### PR DESCRIPTION
This is a small POC to see how we can switch from using the `--local` flag to `--pull` which is both more descriptive and more inline with how podman behaves. This ~is a breaking change~ changes the existing behaviour, but it makes sense as it feels more intuitive and feels better from UX point-of-view.

This PR introduces 3 cases:
- always, which always pulls the container image
- missing, only pulls the container image when it is missing
- never, don't pull the image (which is the same as the previous `--local` flag)