### PR TITLE
Deprecate `--local` flag (HMS-3792)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ sudo podman run \
     -v /var/lib/containers/storage:/var/lib/containers/storage \
     quay.io/centos-bootc/bootc-image-builder:latest \
     --type qcow2 \
-    --local \
 	--use-librepo=True \
     quay.io/centos-bootc/centos-bootc:stream9
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ Flags:
       --progress string       type of progress bar to use (e.g. verbose,term) (default "auto")
       --rootfs string         Root filesystem type. If not given, the default configured in the source container image is used.
       --target-arch string    build for the given target architecture (experimental)
-      --tls-verify            require HTTPS and verify certificates when contacting registries (default true)
       --type stringArray      image types to build [ami, anaconda-iso, gce, iso, qcow2, raw, vhd, vmdk] (default [qcow2])
       --version               version for bootc-image-builder
 
@@ -148,7 +147,6 @@ Global Flags:
 | --output          | output the artifact into the given output directory                                                       |      `.`      |
 | --progress        | Show progress in the given format, supported: verbose,term,debug. If empty it is auto-detected            |     `auto`    |
 | **--rootfs**      | Root filesystem type. Overrides the default from the source container. Supported values: ext4, xfs, btrfs |       ❌      |
-| --tls-verify      | Require HTTPS and verify certificates when contacting registries                                          |     `true`    |
 | **--type**        | [Image type](#-image-types) to build (can be passed multiple times)                                       |     `qcow2`   |
 | --target-arch     | [Target arch](#-target-architecture) to build                                                             |       ❌      |
 | --log-level       | Change log level (debug, info, error)                                                                     |     `error`   |

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -47,9 +47,6 @@ type ManifestConfig struct {
 	// CPU architecture of the image
 	Architecture arch.Arch
 
-	// TLSVerify specifies whether HTTPS and a valid TLS certificate are required
-	TLSVerify bool
-
 	// The minimum size required for the root fs in order to fit the container
 	// contents
 	RootfsMinsize uint64
@@ -319,10 +316,9 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 		return nil, fmt.Errorf("pipeline: no base image defined")
 	}
 	containerSource := container.SourceSpec{
-		Source:    c.Imgref,
-		Name:      c.Imgref,
-		TLSVerify: &c.TLSVerify,
-		Local:     true,
+		Source: c.Imgref,
+		Name:   c.Imgref,
+		Local:  true,
 	}
 
 	var customizations *blueprint.Customizations
@@ -427,10 +423,9 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	}
 
 	containerSource := container.SourceSpec{
-		Source:    c.Imgref,
-		Name:      c.Imgref,
-		TLSVerify: &c.TLSVerify,
-		Local:     true,
+		Source: c.Imgref,
+		Name:   c.Imgref,
+		Local:  true,
 	}
 
 	// The ref is not needed and will be removed from the ctor later

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -194,7 +194,6 @@ func manifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progress
 	imgTypes, _ := cmd.Flags().GetStringArray("type")
 	rpmCacheRoot, _ := cmd.Flags().GetString("rpmmd")
 	targetArch, _ := cmd.Flags().GetString("target-arch")
-	tlsVerify, _ := cmd.Flags().GetBool("tls-verify")
 	rootFs, _ := cmd.Flags().GetString("rootfs")
 	useLibrepo, _ := cmd.Flags().GetBool("use-librepo")
 
@@ -305,7 +304,6 @@ func manifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progress
 		Config:         config,
 		ImageTypes:     imageTypes,
 		Imgref:         imgref,
-		TLSVerify:      tlsVerify,
 		RootfsMinsize:  cntSize * containerSizeToDiskSizeMultiplier,
 		DistroDefPaths: distroDefPaths,
 		SourceInfo:     sourceinfo,
@@ -653,7 +651,10 @@ func buildCobraCmdline() (*cobra.Command, error) {
 	rootCmd.AddCommand(versionCmd)
 
 	rootCmd.AddCommand(manifestCmd)
-	manifestCmd.Flags().Bool("tls-verify", true, "require HTTPS and verify certificates when contacting registries")
+	manifestCmd.Flags().Bool("tls-verify", false, "DEPRECATED: require HTTPS and verify certificates when contacting registries")
+	if err := manifestCmd.Flags().MarkHidden("tls-verify"); err != nil {
+		return nil, fmt.Errorf("cannot hide 'tls-verify' :%w", err)
+	}
 	manifestCmd.Flags().String("rpmmd", "/rpmmd", "rpm metadata cache directory")
 	manifestCmd.Flags().String("target-arch", "", "build for the given target architecture (experimental)")
 	manifestCmd.Flags().StringArray("type", []string{"qcow2"}, fmt.Sprintf("image types to build [%s]", imagetypes.Available()))

--- a/bib/internal/setup/setup.go
+++ b/bib/internal/setup/setup.go
@@ -153,7 +153,9 @@ func validateCanRunTargetArch(targetArch string) error {
 func ValidateHasContainerTags(imgref string) error {
 	output, err := exec.Command("podman", "image", "inspect", imgref, "--format", "{{.Labels}}").Output()
 	if err != nil {
-		return fmt.Errorf("failed inspect image: %w", util.OutputErr(err))
+		return fmt.Errorf(`failed to inspect the image: %w
+bootc-image-builder no longer pulls images, make sure to pull it before running bootc-image-builder:
+    sudo podman pull %s`, util.OutputErr(err), imgref)
 	}
 
 	tags := string(output)

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -416,6 +416,9 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload, gpg_
             ]
             cmd.extend(signed_image_args)
 
+            # Pull the signed image
+            testutil.pull_container(container_ref, tls_verify=False)
+
         cmd.extend([
             *creds_args,
             build_container,
@@ -424,8 +427,8 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload, gpg_
             *upload_args,
             *target_arch_args,
             *tc.bib_rootfs_args(),
-            "--tls-verify=false" if tc.sign else "--tls-verify=true",
             f"--use-librepo={tc.use_librepo}",
+            *tc.bib_rootfs_args()
         ])
 
         # print the build command for easier tracing

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -441,7 +441,6 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload, gpg_
             *upload_args,
             *target_arch_args,
             *tc.bib_rootfs_args(),
-            "--local" if tc.local else "--local=false",
             "--tls-verify=false" if tc.sign else "--tls-verify=true",
             f"--use-librepo={tc.use_librepo}",
         ])

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -31,6 +31,8 @@ def find_image_size_from(manifest_str):
 
 @pytest.mark.parametrize("tc", gen_testcases("manifest"))
 def test_manifest_smoke(build_container, tc):
+    testutil.pull_container(tc.container_ref, tc.target_arch)
+
     output = subprocess.check_output([
         *testutil.podman_run_common,
         build_container,
@@ -50,6 +52,8 @@ def test_manifest_smoke(build_container, tc):
 
 @pytest.mark.parametrize("tc", gen_testcases("anaconda-iso"))
 def test_iso_manifest_smoke(build_container, tc):
+    testutil.pull_container(tc.container_ref, tc.target_arch)
+
     output = subprocess.check_output([
         *testutil.podman_run_common,
         build_container,
@@ -158,6 +162,7 @@ def find_rootfs_type_from(manifest_str):
 @pytest.mark.parametrize("tc", gen_testcases("default-rootfs"))
 def test_manifest_rootfs_respected(build_container, tc):
     # TODO: derive container and fake "bootc install print-configuration"?
+    testutil.pull_container(tc.container_ref)
     output = subprocess.check_output([
         *testutil.podman_run_common,
         build_container,
@@ -197,6 +202,7 @@ def find_user_stage_from(manifest_str):
 def test_manifest_user_customizations_toml(tmp_path, build_container):
     # no need to parameterize this test, toml is the same for all containers
     container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
 
     config_toml_path = tmp_path / "config.toml"
     config_toml_path.write_text(textwrap.dedent("""\
@@ -224,6 +230,7 @@ def test_manifest_user_customizations_toml(tmp_path, build_container):
 
 def test_manifest_installer_customizations(tmp_path, build_container):
     container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
 
     config_toml_path = tmp_path / "config.toml"
     config_toml_path.write_text(textwrap.dedent("""\
@@ -257,6 +264,7 @@ def test_manifest_installer_customizations(tmp_path, build_container):
 def test_mount_ostree_error(tmpdir_factory, build_container):
     # no need to parameterize this test, toml is the same for all containers
     container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
 
     cfg = {
         "blueprint": {
@@ -305,6 +313,7 @@ def test_mount_ostree_error(tmpdir_factory, build_container):
 )
 def test_manifest_checks_build_container_is_bootc(build_container, container_ref, should_error, expected_error):
     def check_image_ref():
+        testutil.pull_container(container_ref)
         subprocess.check_output([
             *testutil.podman_run_common,
             build_container,
@@ -321,6 +330,8 @@ def test_manifest_checks_build_container_is_bootc(build_container, container_ref
 
 @pytest.mark.parametrize("tc", gen_testcases("target-arch-smoke"))
 def test_manifest_target_arch_smoke(build_container, tc):
+    testutil.pull_container(tc.container_ref, tc.target_arch)
+
     # TODO: actually build an image too
     output = subprocess.check_output([
         *testutil.podman_run_common,
@@ -373,6 +384,8 @@ def test_manifest_anaconda_module_customizations(tmpdir_factory, build_container
     config_json_path = output_path / "config.json"
     config_json_path.write_text(json.dumps(cfg), encoding="utf-8")
 
+    testutil.pull_container(tc.container_ref, tc.target_arch)
+
     output = subprocess.check_output([
         *testutil.podman_run_common,
         "-v", f"{output_path}:/output",
@@ -411,6 +424,7 @@ def find_fstab_stage_from(manifest_str):
 ])
 def test_manifest_fs_customizations(tmp_path, build_container, fscustomizations, rootfs):
     container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
 
     config = {
         "customizations": {
@@ -497,7 +511,9 @@ def assert_fs_customizations(customizations, fstype, manifest):
     ({}, "btrfs"),
 ])
 def test_manifest_fs_customizations_xarch(tmp_path, build_container, fscustomizations, rootfs):
+    target_arch = "aarch64"
     container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref, target_arch)
 
     config = {
         "customizations": {
@@ -513,7 +529,7 @@ def test_manifest_fs_customizations_xarch(tmp_path, build_container, fscustomiza
         "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         f"--rootfs={rootfs}",
-        "--target-arch=aarch64",
+        f"--target-arch={target_arch}",
         "manifest", f"{container_ref}",
     ])
 

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -7,8 +7,8 @@ import subprocess
 import textwrap
 
 import pytest
-import testutil
 
+import testutil
 from containerbuild import build_container_fixture  # pylint: disable=unused-import
 from containerbuild import make_container
 from testcases import gen_testcases
@@ -69,6 +69,8 @@ def test_iso_manifest_smoke(build_container, tc):
 
 @pytest.mark.parametrize("tc", gen_testcases("manifest"))
 def test_manifest_disksize(tmp_path, build_container, tc):
+    testutil.pull_container(tc.container_ref, tc.target_arch)
+
     # create derrived container with 6G silly file to ensure that
     # bib doubles the size to 12G+
     cntf_path = tmp_path / "Containerfile"
@@ -114,6 +116,8 @@ def test_manifest_local_checks_containers_storage_errors(build_container):
 
 @pytest.mark.parametrize("tc", gen_testcases("manifest"))
 def test_manifest_local_checks_containers_storage_works(tmp_path, build_container, tc):
+    testutil.pull_container(tc.container_ref, tc.target_arch)
+
     cntf_path = tmp_path / "Containerfile"
     cntf_path.write_text(textwrap.dedent(f"""\n
     FROM {tc.container_ref}
@@ -360,6 +364,8 @@ def find_image_anaconda_stage(manifest_str):
 
 @pytest.mark.parametrize("tc", gen_testcases("anaconda-iso"))
 def test_manifest_anaconda_module_customizations(tmpdir_factory, build_container, tc):
+    testutil.pull_container(tc.container_ref, tc.target_arch)
+
     cfg = {
         "customizations": {
             "installer": {
@@ -383,8 +389,6 @@ def test_manifest_anaconda_module_customizations(tmpdir_factory, build_container
     output_path.mkdir(exist_ok=True)
     config_json_path = output_path / "config.json"
     config_json_path.write_text(json.dumps(cfg), encoding="utf-8")
-
-    testutil.pull_container(tc.container_ref, tc.target_arch)
 
     output = subprocess.check_output([
         *testutil.podman_run_common,
@@ -548,6 +552,7 @@ def find_grub2_iso_stage_from(manifest_str):
 
 def test_manifest_fips_customization(tmp_path, build_container):
     container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
 
     config = {
         "customizations": {
@@ -582,6 +587,7 @@ def find_bootc_install_to_fs_stage_from(manifest_str):
 
 def test_manifest_disk_customization_lvm(tmp_path, build_container):
     container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
 
     config = {
         "customizations": {
@@ -606,6 +612,7 @@ def test_manifest_disk_customization_lvm(tmp_path, build_container):
     with config_path.open("w") as config_file:
         json.dump(config, config_file)
 
+    testutil.pull_container(container_ref)
     output = subprocess.check_output([
         *testutil.podman_run_common,
         "-v", f"{config_path}:/config.json:ro",
@@ -641,6 +648,7 @@ def test_manifest_disk_customization_btrfs(tmp_path, build_container):
     with config_path.open("w") as config_file:
         json.dump(config, config_file)
 
+    testutil.pull_container(container_ref)
     output = subprocess.check_output([
         *testutil.podman_run_common,
         "-v", f"{config_path}:/config.json:ro",
@@ -681,6 +689,7 @@ def test_manifest_disk_customization_swap(tmp_path, build_container):
     with config_path.open("w") as config_file:
         json.dump(config, config_file)
 
+    testutil.pull_container(container_ref)
     output = subprocess.check_output([
         *testutil.podman_run_common,
         "-v", f"{config_path}:/config.json:ro",
@@ -725,6 +734,7 @@ def test_manifest_disk_customization_lvm_swap(tmp_path, build_container):
     with config_path.open("w") as config_file:
         json.dump(config, config_file)
 
+    testutil.pull_container(container_ref)
     output = subprocess.check_output([
         *testutil.podman_run_common,
         "-v", f"{config_path}:/config.json:ro",
@@ -754,6 +764,7 @@ def test_manifest_disk_customization_lvm_swap(tmp_path, build_container):
 def test_iso_manifest_use_librepo(build_container, use_librepo):
     # no need to parameterize this test, --use-librepo behaves same for all containers
     container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
 
     output = subprocess.check_output([
         *testutil.podman_run_common,

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -81,7 +81,7 @@ def test_manifest_disksize(tmp_path, build_container, tc):
         manifest_str = subprocess.check_output([
             *testutil.podman_run_common,
             build_container,
-            "manifest", "--local",
+            "manifest",
             *tc.bib_rootfs_args(),
             f"localhost/{container_tag}",
         ], encoding="utf8")
@@ -100,10 +100,11 @@ def test_manifest_local_checks_containers_storage_errors(build_container):
         "--privileged",
         "--security-opt", "label=type:unconfined_t",
         build_container,
-        "manifest", "--local", "arg-not-used",
+        "manifest", "arg-not-used",
     ], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf8")
     assert res.returncode == 1
-    err = 'local storage not working, did you forget -v /var/lib/containers/storage:/var/lib/containers/storage?'
+    err = 'could not access container storage, ' + \
+        'did you forget -v /var/lib/containers/storage:/var/lib/containers/storage?'
     assert err in res.stderr
 
 
@@ -118,7 +119,7 @@ def test_manifest_local_checks_containers_storage_works(tmp_path, build_containe
         subprocess.run([
             *testutil.podman_run_common,
             build_container,
-            "manifest", "--local",
+            "manifest",
             *tc.bib_rootfs_args(),
             f"localhost/{container_tag}",
         ], check=True, encoding="utf8")
@@ -138,7 +139,7 @@ def test_manifest_cross_arch_check(tmp_path, build_container):
                 *testutil.podman_run_common,
                 build_container,
                 "manifest", "--target-arch=aarch64",
-                "--local", f"localhost/{container_tag}"
+                f"localhost/{container_tag}"
             ], check=True, capture_output=True, encoding="utf8")
         assert 'image found is for unexpected architecture "x86_64"' in exc.value.stderr
 

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -3,6 +3,7 @@ import platform
 import subprocess
 
 import pytest
+import testutil
 # pylint: disable=unused-import
 from containerbuild import build_container_fixture, build_fake_container_fixture
 
@@ -25,6 +26,9 @@ def test_bib_chown_opts(tmp_path, container_storage, build_fake_container, chown
     output_path = tmp_path / "output"
     output_path.mkdir(exist_ok=True)
 
+    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
+
     subprocess.check_call([
         "podman", "run", "--rm",
         "--privileged",
@@ -32,7 +36,7 @@ def test_bib_chown_opts(tmp_path, container_storage, build_fake_container, chown
         "-v", f"{container_storage}:/var/lib/containers/storage",
         "-v", f"{output_path}:/output",
         build_fake_container,
-        "quay.io/centos-bootc/centos-bootc:stream9",
+        container_ref,
     ] + chown_opt)
     expected_output_disk = output_path / "qcow2/disk.qcow2"
     for p in output_path, expected_output_disk:
@@ -52,6 +56,9 @@ def test_opts_arch_is_same_arch_is_fine(tmp_path, build_fake_container, target_a
     output_path = tmp_path / "output"
     output_path.mkdir(exist_ok=True)
 
+    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
+
     res = subprocess.run([
         "podman", "run", "--rm",
         "--privileged",
@@ -60,7 +67,7 @@ def test_opts_arch_is_same_arch_is_fine(tmp_path, build_fake_container, target_a
         "-v", f"{output_path}:/output",
         build_fake_container,
         "--type=iso",
-        "quay.io/centos-bootc/centos-bootc:stream9",
+        container_ref,
     ] + target_arch_opt, check=False, capture_output=True, text=True)
     if expected_err == "":
         assert res.returncode == 0
@@ -80,6 +87,9 @@ def test_bib_tls_opts(tmp_path, container_storage, build_fake_container, tls_opt
     output_path = tmp_path / "output"
     output_path.mkdir(exist_ok=True)
 
+    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
+
     subprocess.check_call([
         "podman", "run", "--rm",
         "--privileged",
@@ -87,7 +97,7 @@ def test_bib_tls_opts(tmp_path, container_storage, build_fake_container, tls_opt
         "-v", f"{container_storage}:/var/lib/containers/storage",
         "-v", f"{output_path}:/output",
         build_fake_container,
-        "quay.io/centos-bootc/centos-bootc:stream9"
+        container_ref,
     ] + tls_opt)
     podman_log = output_path / "podman.log"
     assert expected_cmdline in podman_log.read_text()
@@ -98,6 +108,9 @@ def test_bib_log_level_smoke(tmp_path, container_storage, build_fake_container, 
     output_path = tmp_path / "output"
     output_path.mkdir(exist_ok=True)
 
+    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
+
     log_debug = ["--log-level", "debug"] if with_debug else []
     res = subprocess.run([
         "podman", "run", "--rm",
@@ -107,7 +120,7 @@ def test_bib_log_level_smoke(tmp_path, container_storage, build_fake_container, 
         "-v", f"{output_path}:/output",
         build_fake_container,
         *log_debug,
-        "quay.io/centos-bootc/centos-bootc:stream9"
+        container_ref,
     ], check=True, capture_output=True, text=True)
     assert ('level=debug' in res.stderr) == with_debug
 
@@ -180,6 +193,9 @@ def test_bib_no_outside_container_warning_in_container(tmp_path, container_stora
     output_path = tmp_path / "output"
     output_path.mkdir(exist_ok=True)
 
+    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
+
     res = subprocess.run([
         "podman", "run", "--rm",
         "--privileged",
@@ -187,6 +203,6 @@ def test_bib_no_outside_container_warning_in_container(tmp_path, container_stora
         "-v", f"{container_storage}:/var/lib/containers/storage",
         "-v", f"{output_path}:/output",
         build_fake_container,
-        "quay.io/centos-bootc/centos-bootc:stream9"
+        container_ref,
     ], check=True, capture_output=True, text=True)
     assert "running outside a container" not in res.stderr

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -76,33 +76,6 @@ def test_opts_arch_is_same_arch_is_fine(tmp_path, build_fake_container, target_a
         assert expected_err in res.stderr
 
 
-@pytest.mark.parametrize("tls_opt,expected_cmdline", [
-    ([], "--tls-verify=true"),
-    (["--tls-verify"], "--tls-verify=true"),
-    (["--tls-verify=true"], "--tls-verify=true"),
-    (["--tls-verify=false"], "--tls-verify=false"),
-    (["--tls-verify=0"], "--tls-verify=false"),
-])
-def test_bib_tls_opts(tmp_path, container_storage, build_fake_container, tls_opt, expected_cmdline):
-    output_path = tmp_path / "output"
-    output_path.mkdir(exist_ok=True)
-
-    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
-    testutil.pull_container(container_ref)
-
-    subprocess.check_call([
-        "podman", "run", "--rm",
-        "--privileged",
-        "--security-opt", "label=type:unconfined_t",
-        "-v", f"{container_storage}:/var/lib/containers/storage",
-        "-v", f"{output_path}:/output",
-        build_fake_container,
-        container_ref,
-    ] + tls_opt)
-    podman_log = output_path / "podman.log"
-    assert expected_cmdline in podman_log.read_text()
-
-
 @pytest.mark.parametrize("with_debug", [False, True])
 def test_bib_log_level_smoke(tmp_path, container_storage, build_fake_container, with_debug):
     output_path = tmp_path / "output"

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -144,7 +144,7 @@ def test_bib_errors_only_once(tmp_path, container_storage, build_fake_container)
         build_fake_container,
         "localhost/no-such-image",
     ], check=False, capture_output=True, text=True)
-    needle = "cannot build manifest: failed to pull container image:"
+    needle = "cannot build manifest: failed to inspect the image:"
     assert res.stderr.count(needle) == 1
 
 

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -18,8 +18,6 @@ class TestCase:
     image: str = ""
     # target_arch is the target archicture, empty means current arch
     target_arch: str = ""
-    # local means that the container should be pulled locally ("--local" flag)
-    local: bool = False
     # rootfs to use (e.g. ext4), some containers like fedora do not
     # have a default rootfs. If unset the container default is used.
     rootfs: str = ""

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -215,7 +215,7 @@ def get_ip_from_default_route():
     return default_route.split()[8]
 
 
-def pull_container(container_ref, target_arch=""):
+def pull_container(container_ref, target_arch="", tls_verify=True):
     if target_arch == "":
         target_arch = platform.machine()
 
@@ -225,5 +225,6 @@ def pull_container(container_ref, target_arch=""):
     subprocess.run([
         "podman", "pull",
         "--arch", target_arch,
+        "--tls-verify" if tls_verify else "--tls-verify=false",
         container_ref,
     ], check=True)

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -213,3 +213,17 @@ def get_ip_from_default_route():
         "default"
     ], check=True, capture_output=True, text=True).stdout
     return default_route.split()[8]
+
+
+def pull_container(container_ref, target_arch=""):
+    if target_arch == "":
+        target_arch = platform.machine()
+
+    if target_arch not in ["x86_64", "amd64", "aarch64", "arm64", "s390x", "ppc64le"]:
+        raise RuntimeError(f"unknown host arch: {target_arch}")
+
+    subprocess.run([
+        "podman", "pull",
+        "--arch", target_arch,
+        container_ref,
+    ], check=True)


### PR DESCRIPTION
Pulling container images before building would break in the case of authenticated images on podman machine, since the auth file lives on the host and podman machine and won't know about it.

This commit deprecates the `--local` flag and puts the requirement on the user to ensure that the container is in local storage before initiating the build.
