### PR TITLE
workflow: run tests on "push" to "main" to populate cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - "*"
+  push:
+    branches:
+      - "main"
   # for merge queue
   merge_group:
 


### PR DESCRIPTION
When a merge queue runs it will update the cache in the context of `merge_group`, not `main` [0] - this means that the cache cannot be restored by future PRs and because of the restrictions for caches [1] we currently have no caching.

This is attempt to "fix" this. It sucks a bit because the tests that are run as part of the merge queue will be run again when "main" is updated just so that the cache gets populated. So maybe it's not worth it but right, we need to measure. Either it's this or we can remove the cache action as it is not working right now.

[0] https://github.com/orgs/community/discussions/66430
[1] https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache