### PR TITLE
README,bib: hide `--config` from users, remove from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ for more general information!  Note that outside of initial experimentation, it'
 (or reuse a derived image built via someone else) and then use this project to make a disk image from your custom image.
 
 The generic base images do not include a default user. This example injects a [user configuration file](#-build-config)
-by adding a volume-mount for the local file as well as the `--config` flag to the bootc-image-builder container.
+by adding a volume-mount for the local file to the bootc-image-builder container.
 
 The following command will create a QCOW2 disk image. First, create `./config.toml` as described above to configure user access.
 
@@ -113,7 +113,6 @@ Usage:
 
 Flags:
       --chown string           chown the ouput directory to match the specified UID:GID
-      --config string          build config file (default: /config.toml if present)
       --tls-verify             require HTTPS and verify certificates when contacting registries (default true)
       --type string            image type to build [qcow2, ami] (default "qcow2")
       --target-arch string     architecture to build image for (default is the native architecture)
@@ -124,7 +123,6 @@ Flags:
 | Argument          | Description                                                                                        | Default Value |
 |-------------------|----------------------------------------------------------------------------------------------------|:-------------:|
 | **--chown**       | chown the output directory to match the specified UID:GID                                          |       ❌      |
-| **--config**      | Path to a [build config](#-build-config)                                                           |       ❌      |
 | **--rootfs**      | Root filesystem type. Overrides the default from the source container. Supported values: ext4, xfs |
 | **--tls-verify**  | Require HTTPS and verify certificates when contacting registries                                   |    `true`     |
 | **--type**        | [Image type](#-image-types) to build                                                               |    `qcow2`    |
@@ -257,7 +255,7 @@ The following volumes can be mounted inside the container:
 
 ## 📝 Build config
 
-A build config is a Toml (or JSON) file with customizations for the resulting image. A path to the file is passed via  the `--config` argument. The customizations are specified under a `customizations` object.
+A build config is a Toml (or JSON) file with customizations for the resulting image. The config file is mapped into the container directory to `/config.toml`. The customizations are specified under a `customizations` object.
 
 As an example, let's show how you can add a user to the image:
 

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -548,12 +548,18 @@ func run() error {
 	}
 	rootCmd.AddCommand(manifestCmd)
 	manifestCmd.Flags().Bool("tls-verify", true, "require HTTPS and verify certificates when contacting registries")
-	manifestCmd.Flags().String("config", "", "build config file; /config.json will be used if present")
 	manifestCmd.Flags().String("rpmmd", "/rpmmd", "rpm metadata cache directory")
 	manifestCmd.Flags().String("target-arch", "", "build for the given target architecture (experimental)")
 	manifestCmd.Flags().StringArray("type", []string{"qcow2"}, fmt.Sprintf("image types to build [%s]", allImageTypesString()))
 	manifestCmd.Flags().Bool("local", false, "use a local container rather than a container from a registry")
 	manifestCmd.Flags().String("rootfs", "", "Root filesystem type. If not given, the default configured in the source container image is used.")
+	// --config is only useful for developers who run bib outside
+	// of a container to generate a manifest. so hide it by
+	// default from users.
+	manifestCmd.Flags().String("config", "", "build config file; /config.json will be used if present")
+	if err := manifestCmd.Flags().MarkHidden("config"); err != nil {
+		return fmt.Errorf("cannot hide 'config' :%w", err)
+	}
 
 	buildCmd.Flags().AddFlagSet(manifestCmd.Flags())
 	buildCmd.Flags().String("aws-ami-name", "", "name for the AMI in AWS (only for type=ami)")

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -110,3 +110,22 @@ def test_bib_log_level_smoke(tmp_path, container_storage, build_fake_container, 
         "quay.io/centos-bootc/centos-bootc:stream9"
     ], check=True, capture_output=True, text=True)
     assert ('level=debug' in res.stderr) == with_debug
+
+
+def test_bib_help_hides_config(tmp_path, container_storage, build_fake_container):
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+
+    res = subprocess.run([
+        "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
+        "-v", f"{container_storage}:/var/lib/containers/storage",
+        "-v", f"{output_path}:/output",
+        build_fake_container,
+        "manifest", "--help",
+    ], check=True, capture_output=True, text=True)
+    # --config should not be user visible
+    assert '--config' not in res.stdout
+    # but other options should be
+    assert '--log-level' in res.stdout


### PR DESCRIPTION
With the default to pick up the config from `/config.{toml,json}` nowdays the `--config` flag is not very useful anymore. It is actually confusing users as they may hink they to pass two config arguments into the container.

So this commit removes `--config` from the README and hides it in bib. It is not removed entirely for two reasons:
1. backward compatibility with existing scripts
2. it is useful for developers to run
```
$ sudo ./bootc-image-builder manifest --config local-config.json
```
to get a manifest from outside a container for debugging purposes (but it's not a strong reason).