### PR TITLE
README: mention/link to bootc podman desktop extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Have [podman](https://podman.io/) installed on your system. Either through your 
 Linux or through [Podman Desktop](https://podman.io/) if you are on macOS or Windows. If you want to run the resulting
 virtual machine(s) or installer media you can use [qemu](https://www.qemu.org/).
 
+A very nice GUI extension for Podman Desktop is also
+[available](https://github.com/containers/podman-desktop-extension-bootc).
+When using this the commandline examples below are all handlded by
+podman desktop.
+
 On macOS, the podman machine must be running in rootful mode:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ virtual machine(s) or installer media you can use [qemu](https://www.qemu.org/).
 
 A very nice GUI extension for Podman Desktop is also
 [available](https://github.com/containers/podman-desktop-extension-bootc).
-When using this the commandline examples below are all handlded by
-podman desktop.
+The command line examples below can be all handled by
+Podman Desktop.
 
 On macOS, the podman machine must be running in rootful mode:
 


### PR DESCRIPTION
As suggested by Charlie (thanks!) this commit adds a description and link to the podman desktop bootc extension.

Closes: https://github.com/osbuild/bootc-image-builder/issues/449