### PR TITLE
[RFC] add new `adduser-ssh` command to simplify user creation

### DIFF
--- a/bib/cmd/adduser-ssh/main.go
+++ b/bib/cmd/adduser-ssh/main.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// for tests
+	rootdir = os.Getenv("OS_TOOLBOX_ADDUSER_ROOT")
+
+	ghSSHKeyAPIFmt = "https://api.github.com/users/%s/keys"
+)
+
+func getSSHKeyGH(username string) (string, error) {
+	resp, err := http.Get(fmt.Sprintf(ghSSHKeyAPIFmt, url.PathEscape(username)))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("cannot read ssh key data: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected http status when fetching ssh-key for %q: %v body:\n%s", username, resp.StatusCode, body)
+	}
+
+	var ghKeys []struct {
+		ID  int    `json:"id"`
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal(body, &ghKeys); err != nil {
+		return "", fmt.Errorf("cannot unmarshal ssh keys for %q: %w", username, err)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	for _, ghkey := range ghKeys {
+		fmt.Fprintf(buf, "# key for gh:%q (id: %v)\n", username, ghkey.ID)
+		fmt.Fprintf(buf, "%s\n", ghkey.Key)
+	}
+
+	return buf.String(), nil
+}
+
+func getAuthorizedKeysContent(username, keySpec string) (string, error) {
+	switch {
+	case keySpec == "":
+		return "", nil
+	case strings.HasPrefix(keySpec, "gh:"):
+		return getSSHKeyGH(strings.TrimPrefix(keySpec, "gh:"))
+	default:
+		return fmt.Sprintf("# key for %s from cmdline\n%s\n", username, keySpec), nil
+	}
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	username := args[0]
+
+	// deal with ssh keys
+	keySpec, _ := cmd.Flags().GetString("ssh-key")
+	authorizedKeysContent, err := getAuthorizedKeysContent(username, keySpec)
+	if err != nil {
+		return fmt.Errorf("cannot get ssh-key: %w", err)
+	}
+	if authorizedKeysContent != "" {
+		// XXX: customize path, suport adduser options
+		var homePath string
+		if username == "root" {
+			homePath = filepath.Join(rootdir, "/var/roothome/.ssh")
+		} else {
+			homePath = filepath.Join(rootdir, "/var/home/", username, ".ssh")
+		}
+		// XXX: customize perms
+		if err := os.MkdirAll(homePath, 0o700); err != nil && !os.IsExist(err) {
+			return err
+		}
+		authorizedKeysPath := filepath.Join(homePath, "authorized_keys")
+		// XXX: make nicer, make part of e.g. getAuthorizedKeysContent()
+		preamble := fmt.Sprintf("# created by adduser-ssh on %s\n", time.Now().Format(time.RFC822Z))
+		content := preamble + authorizedKeysContent
+		if err := os.WriteFile(authorizedKeysPath, []byte(content), 0600); err != nil {
+			return err
+		}
+		fmt.Printf("created %q\n", authorizedKeysPath)
+	}
+
+	if skipUseradd, _ := cmd.Flags().GetBool("skip-useradd"); !skipUseradd {
+		// now run adduser and pass options verbatim
+		acmd := exec.Command("useradd", username)
+		acmd.Args = append(acmd.Args, args[1:]...)
+		acmd.Stdout = os.Stdout
+		acmd.Stderr = os.Stderr
+		if err := acmd.Run(); err != nil {
+			return fmt.Errorf("cannot run %v: %w", acmd, err)
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	var rootCmd = &cobra.Command{
+		Use:           "adduser-ssh [user]",
+		Short:         "Wrapper around adduser with sshkey adding",
+		Args:          cobra.MinimumNArgs(1),
+		RunE:          run,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	rootCmd.Flags().String("ssh-key", "", "Specificy the ssh key to use (verbatim or gh:>user-id>)")
+	rootCmd.Flags().Bool("skip-useradd", false, "Do not run useradd")
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+}

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ CONTAINERS_STORAGE_THIN_TAGS="containers_image_openpgp exclude_graphdriver_btrfs
 cd bib
 set -x
 go build -tags "${CONTAINERS_STORAGE_THIN_TAGS}" -o ../bin/bootc-image-builder ./cmd/bootc-image-builder
+go build -o ../bin/adduser-ssh ./cmd/adduser-ssh
 
 # expand the list as we support more architectures
 for arch in amd64 arm64; do

--- a/test/test_adduser.py
+++ b/test/test_adduser.py
@@ -1,0 +1,58 @@
+import subprocess
+import textwrap
+
+import pytest
+
+import testutil
+
+if not testutil.has_executable("podman"):
+    pytest.skip("no podman, skipping integration tests that required podman", allow_module_level=True)
+
+from containerbuild import build_container_fixture, make_container  # noqa: F401
+
+
+def test_adduser_ssh_smoke(tmp_path, build_container):
+    # no need to parameterize this test, adduser-ssh is the same for all containers
+    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+
+    # create container that uses our adduser during the build
+    cntf_path = tmp_path / "Containerfile"
+    cntf_path.write_text(textwrap.dedent(f"""\n
+    FROM {build_container} AS toolbox_stage
+
+    FROM {container_ref}
+    RUN --mount=type=bind,from=toolbox_stage,target=/toolbox \
+      /toolbox/usr/bin/adduser-ssh --ssh-key foo-key foo -- -c "comment for foo"
+    RUN --mount=type=bind,from=toolbox_stage,target=/toolbox \
+      /toolbox/usr/bin/adduser-ssh --ssh-key root-key --skip-useradd root;
+    """), encoding="utf8")
+
+    with make_container(tmp_path) as container_tag:
+        print(f"using {container_tag}")
+        # assert user got added
+        output = subprocess.check_output([
+            "podman", "run", "--rm",
+            '--entrypoint=["/usr/bin/cat", "/etc/passwd"]',
+            container_tag,
+        ], encoding="utf8")
+        # XXX: is /var/home correct in this context?
+        assert "\nfoo:x:1000:1000:comment for foo:/var/home/foo:/bin/bash\n" in output
+
+        output = subprocess.check_output([
+            "podman", "run", "--rm",
+            '--entrypoint=["/usr/bin/cat", "/root/.ssh/authorized_keys", "/home/foo/.ssh/authorized_keys"]',
+            container_tag,
+        ], encoding="utf8")
+        # assert our key got written
+        assert "# created by adduser-ssh on " in output
+        assert "# key for root from cmdline\nroot-key\n" in output
+        assert "# key for foo from cmdline\nfoo-key" in output
+        # XXX: check permissions
+
+        # but it is a bootc one
+        output = subprocess.check_output([
+            "podman", "run", "--rm",
+            '--entrypoint=["/usr/bin/test", "-d", "/ostree"]',
+            container_tag,
+        ], encoding="utf8")
+        assert output == ""


### PR DESCRIPTION
In various issue (e.g. https://gitlab.com/fedora/bootc/tracker/-/issues/2) and during devconf the idea of a `os-toolbox` (or `sdk`, `osbuild-sdk`, `osbuild`, `<insert-name-here>` got discussed). Broadly speaking there are two use-cases for this (quoting Colin here):
1.  A container usable in a container build to mutate that build, e.g. to make user creation simpler
2.   A container usable outside of a container build (like bib) to perform generic tasks (but often operating on reference to an input bootc container), e.g. to make running `bootc-image-builder` simpler

On my way back from devconf I was drafting a quick prototype for (1) with the user-creation in mind. I picked it because it seems the highest value target, i.e. user creation with ssh is a bit complicated right now and helping our users to get started more easily (and pleasantly) seems worthwhile.

Below is this prototype and an explanation how it works. It currently is part of the "bootc-iamge-builder" container but the code could live anywhere, I have no strong options here but it does seem sensible to me to have a `os-toolbox` (name strawman) that would contain both the `useradd-ssh` (or `bootc-useradd`, `adduser-ssh` or whatever we call it) and bib.

Feedback very welcome. The code needs more unit tests (and input validation) but the added integration test is working for me within the limited scope (i.e. it does not build and image and boots/logins into it). I'm happy to flesh this out more once there is concensus that this is the right direction (and the right language as there is an argument for doing this in rust).

--- 

In order to add user with ssh keys to an bootc image a fairly complicated commandline is used today [0]:
```Containerfile
FROM quay.io/centos-bootc/centos-bootc:stream9
COPY wheel-nopasswd /etc/sudoers.d
ARG sshpubkey
RUN if test -z "$sshpubkey"; then echo "must provide sshpubkey"; exit 1; fi; \
    useradd -G wheel exampleuser && \
    mkdir -m 0700 -p /home/exampleuser/.ssh && \
    echo $sshpubkey > /home/exampleuser/.ssh/authorized_keys && \
    chmod 0600 /home/exampleuser/.ssh/authorized_keys && \
    chown -R exampleuser: /home/exampleuser
```

With this commit this can be simplified to something like:
```Containerfile
FROM quay.io/bootc/os-toolbox AS toolbox_stage

FROM quay.io/centos-bootc/centos-bootc:stream9
RUN --mount=type=bind,from=toolbox_stage,target=/toolbox \
  /toolbox/usr/bin/adduser-ssh --ssh-key gh:exampleuser --sudo-wheel-nopasswd exampleuser -- -G wheel
```
Note that anythign after `--` is passed through to `useradd` so the user is still flexible.

[edit: also note that the `--sudo-wheel-nopasswd` is not implemened yet and only there to illustrate the idea behind this helper]
[edit2: there is also https://gitlab.com/fedora/bootc/osbuild-cfg/ which is slightly different but has overlap]