### PR TITLE
Fix ISO for Fedora 40 and add Fedora 40 CI

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -248,6 +248,10 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 		img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")
 	}
 
+	// use lorax-templates-rhel if the source distro is not Fedora with the exception of Fedora ELN
+	img.UseRHELLoraxTemplates =
+		c.SourceInfo.OSRelease.ID != "fedora" || c.SourceInfo.OSRelease.VersionID == "eln"
+
 	switch c.Architecture {
 	case arch.ARCH_X86_64:
 		img.Platform = &platform.X86{

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.53.5
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/google/uuid v1.6.0
-	github.com/osbuild/images v0.61.0
+	github.com/osbuild/images v0.67.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
@@ -123,7 +123,7 @@ require (
 	golang.org/x/term v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/tools v0.19.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240429193739-8cf5692501f6 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240513163218-0867130af1f8 // indirect
 	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/go-jose/go-jose.v2 v2.6.1 // indirect

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -281,8 +281,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/osbuild/images v0.61.0 h1:bCU4+SrfSlyesGb6RfC9p4fbHmD909ww61TW3wsYNGA=
-github.com/osbuild/images v0.61.0/go.mod h1:0X7LQ2czXhbtatmC/xsCwK1tUS10kkAXng1wKJKHK9Q=
+github.com/osbuild/images v0.67.0 h1:6DNp0eOVxoUkyIp6XcHXQDbCwiPgQtc8hRH3nfTCf/Q=
+github.com/osbuild/images v0.67.0/go.mod h1:kkiJNrd0XkVfwBxrJ8wWt6/d0+Eb+tG+zZVnw/xXE/8=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
@@ -514,9 +514,9 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda h1:wu/KJm9KJwpfHWhkkZGohVC6KRrc1oJNr4jwtQMOQXw=
-google.golang.org/genproto/googleapis/api v0.0.0-20240429193739-8cf5692501f6 h1:DTJM0R8LECCgFeUwApvcEJHz85HLagW8uRENYxHh1ww=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240429193739-8cf5692501f6 h1:DujSIu+2tC9Ht0aPNA7jgj23Iq8Ewi5sgkQ++wdvonE=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240429193739-8cf5692501f6/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
+google.golang.org/genproto/googleapis/api v0.0.0-20240513163218-0867130af1f8 h1:W5Xj/70xIA4x60O/IFyXivR5MGqblAb8R3w26pnD6No=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240513163218-0867130af1f8 h1:mxSlqyb8ZAHsYDCfiXN1EDdNTdvjUJSLY+OnAUtYNYA=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240513163218-0867130af1f8/go.mod h1:I7Y+G38R2bu5j1aLzfFmQfTcU/WnFuqDwLZAbvKTKpM=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/bib/internal/source/source.go
+++ b/bib/internal/source/source.go
@@ -14,6 +14,7 @@ type OSRelease struct {
 	ID         string
 	VersionID  string
 	Name       string
+	VariantID  string
 }
 
 type Info struct {
@@ -22,6 +23,7 @@ type Info struct {
 }
 
 func validateOSRelease(osrelease map[string]string) error {
+	// VARIANT_ID is optional
 	for _, key := range []string{"ID", "VERSION_ID", "NAME", "PLATFORM_ID"} {
 		if _, ok := osrelease[key]; !ok {
 			return fmt.Errorf("missing %s in os-release", key)
@@ -73,6 +75,7 @@ func LoadInfo(root string) (*Info, error) {
 			VersionID:  osrelease["VERSION_ID"],
 			Name:       osrelease["NAME"],
 			PlatformID: osrelease["PLATFORM_ID"],
+			VariantID:  osrelease["VARIANT_ID"],
 		},
 
 		UEFIVendor: vendor,

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -285,6 +285,7 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
             *upload_args,
             *target_arch_args,
             "--local" if local else "--local=false",
+            "--rootfs", "ext4",
         ])
 
         # print the build command for easier tracing

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -20,7 +20,7 @@ INSTALLER_IMAGE_TYPES = ("anaconda-iso",)
 def gen_testcases(what):
     # bootc containers that are tested by default
     CONTAINERS_TO_TEST = {
-        "fedora": "quay.io/centos-bootc/fedora-bootc:eln",
+        "fedora": "quay.io/fedora/fedora-bootc:40",
         "centos": "quay.io/centos-bootc/centos-bootc:stream9",
     }
     # allow commandline override, this is used when testing
@@ -34,6 +34,9 @@ def gen_testcases(what):
 
     if what == "manifest":
         return CONTAINERS_TO_TEST.values()
+    elif what == "default-rootfs":
+        # Fedora doesn't have a default rootfs
+        return [CONTAINERS_TO_TEST["centos"]]
     elif what == "ami-boot":
         return [cnt + ",ami" for cnt in CONTAINERS_TO_TEST.values()]
     elif what == "anaconda-iso":


### PR DESCRIPTION
We currently cannot build Fedora 40 ISO because we require lorax-templates-rhel everywhere. Let's parametrize it based on the distribution. Also, let's add Fedora 40 tests.

Fixes #421 