### PR TITLE
main: set `SilenceErrors` to avoid double error printing

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -528,6 +528,7 @@ func run() error {
 		Use:               "bootc-image-builder",
 		Long:              "create a bootable image from an ostree native container",
 		PersistentPreRunE: rootPreRunE,
+		SilenceErrors:     true,
 	}
 
 	rootCmd.PersistentFlags().StringVar(&rootLogLevel, "log-level", "", "logging level (debug, info, error); default error")


### PR DESCRIPTION
We handle the errors ourselfs in bootc-image-builder but there was a setting missing which lead to double prints:
```
$ go build && sudo ./bootc-image-builder manifest quay.io/fedora/fedora-bootc:40
Error: cannot generate manifest: cannot get rootfs type for container: container does not include a default root filesystem type
2024/06/24 10:26:42 error: cannot generate manifest: cannot get rootfs type for container: container does not include a default root filesystem type
```

This commit fixes this and adds a test:
```
$ go build && sudo ./bootc-image-builder manifest quay.io/fedora/fedora-bootc:40
2024/06/24 10:43:38 error: cannot generate manifest: cannot get rootfs type for container: container does not include a default root filesystem type
```