### PR TITLE
bib: use `util.OutputErr()` in manifestFromCobra()

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -217,8 +217,8 @@ func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, *mTLSConfig, 
 	// We might want to change this behaviour in the future to match podman.
 	if !localStorage {
 		logrus.Infof("Pulling image %s (arch=%s)\n", imgref, cntArch)
-		if output, err := exec.Command("podman", "pull", "--arch", cntArch.String(), fmt.Sprintf("--tls-verify=%v", tlsVerify), imgref).CombinedOutput(); err != nil {
-			return nil, nil, fmt.Errorf("failed to pull container image: %w\n%s", err, output)
+		if _, err := exec.Command("podman", "pull", "--arch", cntArch.String(), fmt.Sprintf("--tls-verify=%v", tlsVerify), imgref).Output(); err != nil {
+			return nil, nil, fmt.Errorf("failed to pull container image: %w", util.OutputErr(err))
 		}
 	} else {
 		logrus.Debug("Using local container")


### PR DESCRIPTION
The error when running without a valid container looks like this:
```
$ go build && sudo ./bootc-image-builder manifest no-such-thing
2024/06/24 11:19:29 error: cannot generate manifest: failed to pull container image: exit status 125
Error: short-name "no-such-thing" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```
right now. The second error and the first are a bit diconnected but in fact the second is the output from the failed pull command. So this trivial PR changes the error to use `util.OutputError` instead which makes clearer where the second line comes from:
```
$ go build && sudo ./bootc-image-builder manifest no-such-thing
2024/06/24 11:33:26 error: cannot generate manifest: failed to pull container image: exit status 125, stderr:
Error: short-name "no-such-thing" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```
(i.e. notice the little `stderr:` in there). We could think about more formating here but this is probably a good starting point :)