### PR TITLE
bib: improve error when a container does not contain a default rootfs

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -245,9 +245,12 @@ func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, *mTLSConfig, 
 	if rootFs != "" {
 		rootfsType = rootFs
 	} else {
-		rootfsType, err = container.RootfsType()
+		rootfsType, err = container.DefaultRootfsType()
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot get rootfs type for container: %w", err)
+		}
+		if rootfsType == "" {
+			return nil, nil, fmt.Errorf(`no default root filesystem type specified in container, please use "--rootfs" to set manually`)
 		}
 	}
 

--- a/bib/internal/container/container.go
+++ b/bib/internal/container/container.go
@@ -136,7 +136,10 @@ func (c *Container) InitDNF() error {
 	return nil
 }
 
-func (c *Container) RootfsType() (string, error) {
+// DefaultRootfsType returns the default rootfs type (e.g. "ext4") as
+// specified by the bootc container install configuration. An empty
+// string is valid and means the container sets no default.
+func (c *Container) DefaultRootfsType() (string, error) {
 	output, err := exec.Command("podman", "exec", c.id, "bootc", "install", "print-configuration").Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to run bootc install print-configuration: %w", util.OutputErr(err))
@@ -166,7 +169,7 @@ func (c *Container) RootfsType() (string, error) {
 	supportedFS := []string{"ext4", "xfs"}
 
 	if fsType == "" {
-		return "", fmt.Errorf("container does not include a default root filesystem type")
+		return "", nil
 	}
 	if !slices.Contains(supportedFS, fsType) {
 		return "", fmt.Errorf("unsupported root filesystem type: %s, supported: %s", fsType, strings.Join(supportedFS, ", "))


### PR DESCRIPTION
Tweak the error output when a bootc container does not contain a default filesystem. The new error will hint what commandline option to use. The error message generation is also moved from the helper into the main program because only the main.go knows what options it supports.

The error is now:
```
$ go build && sudo ./bootc-image-builder manifest quay.io/fedora/fedora-bootc:40
Error: cannot generate manifest: no default root filesystem type specified in container, please use "--rootfs" to set manually
2024/06/24 11:39:39 error: cannot generate manifest: no default root filesystem type specified in container, please use "--rootfs" to set manually
```