### PR TITLE
Add support for ppc64le architecture

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -145,6 +145,13 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 			},
 			Zipl: true,
 		}
+	case arch.ARCH_PPC64LE:
+		img.Platform = &platform.PPC64LE{
+			BasePlatform: platform.BasePlatform{
+				QCOW2Compat: "1.1",
+			},
+			BIOS: true,
+		}
 	}
 
 	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {

--- a/bib/cmd/bootc-image-builder/partition_tables.go
+++ b/bib/cmd/bootc-image-builder/partition_tables.go
@@ -150,4 +150,41 @@ var partitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
+	arch.ARCH_PPC64LE.String(): disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size:     4 * MebiByte,
+				Type:     disk.PRePartitionGUID,
+				Bootable: true,
+			},
+			{
+				Size: 500 * MebiByte,
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: BootOptions,
+					FSTabFreq:    1,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 2 * GibiByte,
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: RootOptions,
+					FSTabFreq:    1,
+					FSTabPassNo:  1,
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
bootc-image-builder lacks support for ppc64le.
This two patch series adds such support.
 - Update manifestForDiskImage to include support for ppc64le architecture
 - Update partition table map with ppc64le specific data

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>