### PR TITLE
build: include git revision in main "bootc-image-binary"

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,6 +6,8 @@ RUN go env -w GOPROXY=$GOPROXY
 RUN cd /build/bib && go mod download
 COPY build.sh /build
 COPY bib /build/bib
+# the ".git" dir will allow go build to automatically include build info
+COPY .git /build/.git
 WORKDIR /build
 RUN ./build.sh
 

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -146,3 +146,21 @@ def test_bib_errors_only_once(tmp_path, container_storage, build_fake_container)
     ], check=False, capture_output=True, text=True)
     needle = "cannot build manifest: failed to pull container image:"
     assert res.stderr.count(needle) == 1
+
+
+def test_bib_version(tmp_path, container_storage, build_fake_container):
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+
+    res = subprocess.run([
+        "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
+        "-v", f"{container_storage}:/var/lib/containers/storage",
+        "-v", f"{output_path}:/output",
+        "--entrypoint=/usr/bin/bootc-image-builder",
+        build_fake_container,
+        "version",
+    ], check=True, capture_output=True, text=True)
+    needle = "revision: "
+    assert needle in res.stdout


### PR DESCRIPTION
For easier tracing of what revision was used by who this commit adds the git revision to the main `bootc-image-builder` binary.

To do this we need to include the git tree in the build container, this should be enough but for some reason, see bib issue#511 the build-in `go build` vcs info is not picked up. So this includes a workaround to manually stamp the revision.

[edit: this should help with questions like https://github.com/osbuild/bootc-image-builder/pull/489#issuecomment-2197787396 - ie make it trivial to see what git revision the user is using)]