### PR TITLE
test: unify how `--entrypoint=` is used

### DIFF
--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -39,8 +39,9 @@ def test_manifest_smoke(build_container, testcase_ref):
         "podman", "run", "--rm",
         "--privileged",
         "--security-opt", "label=type:unconfined_t",
-        f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--rootfs", "ext4", "{container_ref}"]',
+        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
+        "manifest", "--rootfs", "ext4", f"{container_ref}",
     ])
     manifest = json.loads(output)
     # just some basic validation
@@ -61,9 +62,10 @@ def test_iso_manifest_smoke(build_container, testcase_ref):
         "podman", "run", "--rm",
         "--privileged",
         "--security-opt", "label=type:unconfined_t",
-        ('--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--rootfs", "ext4", '
-         f'"--type=anaconda-iso", "{container_ref}"]'),
+        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
+        "manifest", "--rootfs", "ext4",
+        "--type=anaconda-iso", f"{container_ref}",
     ])
     manifest = json.loads(output)
     # just some basic validation
@@ -111,8 +113,9 @@ def test_manifest_local_checks_containers_storage_errors(build_container):
         "podman", "run", "--rm",
         "--privileged",
         "--security-opt", "label=type:unconfined_t",
-        '--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--local", "arg-not-used"]',
+        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
+        "manifest", "--local", "arg-not-used",
     ], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf8")
     assert res.returncode == 1
     err = 'local storage not working, did you forget -v /var/lib/containers/storage:/var/lib/containers/storage?'
@@ -132,7 +135,7 @@ def test_manifest_local_checks_containers_storage_works(tmp_path, build_containe
             "--privileged",
             "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
             "--security-opt", "label=type:unconfined_t",
-            "--entrypoint", "/usr/bin/bootc-image-builder",
+            "--entrypoint=/usr/bin/bootc-image-builder",
             build_container,
             "manifest", "--local", "--rootfs", "ext4", f"localhost/{container_tag}",
         ], check=True, encoding="utf8")
@@ -153,10 +156,10 @@ def test_manifest_cross_arch_check(tmp_path, build_container):
                 "--privileged",
                 "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
                 "--security-opt", "label=type:unconfined_t",
-                f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest",\
-                   "--target-arch=aarch64", "--rootfs", "ext4", "--local", \
-                   "localhost/{container_tag}"]',
+                "--entrypoint=/usr/bin/bootc-image-builder",
                 build_container,
+                "manifest", "--target-arch=aarch64",
+                "--rootfs", "ext4", "--local", f"localhost/{container_tag}"
             ], check=True, capture_output=True, encoding="utf8")
         assert 'image found is for unexpected architecture "x86_64"' in exc.value.stderr
 
@@ -182,8 +185,9 @@ def test_manifest_rootfs_respected(build_container, testcase_ref):
         "podman", "run", "--rm",
         "--privileged",
         "--security-opt", "label=type:unconfined_t",
-        f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "{container_ref}"]',
+        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
+        "manifest", f"{container_ref}",
     ])
     rootfs_type = find_rootfs_type_from(output)
     match container_ref:
@@ -201,9 +205,9 @@ def test_manifest_rootfs_override(build_container):
         "podman", "run", "--rm",
         "--privileged",
         "--security-opt", "label=type:unconfined_t",
-        f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest",\
-           "--rootfs", "ext4", "{container_ref}"]',
+        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
+        "manifest", "--rootfs", "ext4", f"{container_ref}",
     ])
     rootfs_type = find_rootfs_type_from(output)
     assert rootfs_type == "ext4"
@@ -237,8 +241,9 @@ def test_manifest_user_customizations_toml(tmp_path, build_container):
         "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
         "-v", f"{config_toml_path}:/config.toml",
         "--security-opt", "label=type:unconfined_t",
-        f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--rootfs", "ext4", "{container_ref}"]',
+        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
+        "manifest", "--rootfs", "ext4", f"{container_ref}",
     ])
     user_stage = find_user_stage_from(output)
     assert user_stage["options"]["users"].get("alice") == {
@@ -266,8 +271,9 @@ def test_manifest_installer_customizations(tmp_path, build_container):
         "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
         "-v", f"{config_toml_path}:/config.toml",
         "--security-opt", "label=type:unconfined_t",
-        f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--type=anaconda-iso", "{container_ref}"]',
+        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
+        "manifest", "--type=anaconda-iso", f"{container_ref}",
     ])
     manifest = json.loads(output)
 
@@ -322,8 +328,9 @@ def test_mount_ostree_error(tmpdir_factory, build_container):
             "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
             "--security-opt", "label=type:unconfined_t",
             "-v", f"{output_path}:/output",
-            f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "--rootfs", "ext4", "{container_ref}"]',
+            "--entrypoint=/usr/bin/bootc-image-builder",
             build_container,
+            "manifest", "--rootfs", "ext4", f"{container_ref}",
             "--config", "/output/config.json",
         ], stderr=subprocess.PIPE, encoding="utf8")
     assert 'The following custom mountpoints are not supported ["/ostree"]' in exc.value.stderr

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -122,6 +122,7 @@ def test_bib_help_hides_config(tmp_path, container_storage, build_fake_container
         "--security-opt", "label=type:unconfined_t",
         "-v", f"{container_storage}:/var/lib/containers/storage",
         "-v", f"{output_path}:/output",
+        "--entrypoint=/usr/bin/bootc-image-builder",
         build_fake_container,
         "manifest", "--help",
     ], check=True, capture_output=True, text=True)


### PR DESCRIPTION
The usage of `--entrypoint` was a bit all over the place. This commit unifies it so that if the entrypoint is not "build" we always pass `--entrypoint=/usr/bin/bootc-image-builder` and the the arguments to bib are passed after the container.

This makes test (hopefully) more readable.