### PR TITLE
main: allow running outside of a container

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -76,6 +76,16 @@ func canChownInPath(path string) (bool, error) {
 	return checkFile.Chown(osGetuid(), osGetgid()) == nil, nil
 }
 
+func inContainerOrUnknown() bool {
+	// no systemd-detect-virt, err on the side of container
+	if _, err := exec.LookPath("systemd-detect-virt"); err != nil {
+		return true
+	}
+	// exit code "0" means the container is detected
+	err := exec.Command("systemd-detect-virt", "-c", "-q").Run()
+	return err == nil
+}
+
 // getContainerSize returns the size of an already pulled container image in bytes
 func getContainerSize(imgref string) (uint64, error) {
 	output, err := exec.Command("podman", "image", "inspect", imgref, "--format", "{{.Size}}").Output()
@@ -377,8 +387,13 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot validate the setup: %w", err)
 	}
 	logrus.Debug("Ensuring environment setup")
-	if err := setup.EnsureEnvironment(osbuildStore); err != nil {
-		return fmt.Errorf("cannot ensure the environment: %w", err)
+	switch inContainerOrUnknown() {
+	case false:
+		fmt.Fprintf(os.Stderr, "WARNING: running outside a container, this is an unsupported configuration\n")
+	case true:
+		if err := setup.EnsureEnvironment(osbuildStore); err != nil {
+			return fmt.Errorf("cannot ensure the environment: %w", err)
+		}
 	}
 
 	if err := os.MkdirAll(outputDir, 0777); err != nil {

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -164,3 +164,19 @@ def test_bib_version(tmp_path, container_storage, build_fake_container):
     ], check=True, capture_output=True, text=True)
     needle = "revision: "
     assert needle in res.stdout
+
+
+def test_bib_no_outside_container_warning_in_container(tmp_path, container_storage, build_fake_container):
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+
+    res = subprocess.run([
+        "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
+        "-v", f"{container_storage}:/var/lib/containers/storage",
+        "-v", f"{output_path}:/output",
+        build_fake_container,
+        "quay.io/centos-bootc/centos-bootc:stream9"
+    ], check=True, capture_output=True, text=True)
+    assert "running outside a container" not in res.stderr


### PR DESCRIPTION
It can be useful to run `bootc-image-builder` outside a container, e.g. during local development. Let's allow it but warn the user that it's not a supported configuration.

[my main use-case is to run the experimental progress bar as it's hard to automatically test]