### PR TITLE
main,osbuildprogress: add `--progress=text` support (COMPOSER-2394)

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/osbuild/bootc-image-builder/bib/internal/buildconfig"
 	podman_container "github.com/osbuild/bootc-image-builder/bib/internal/container"
 	"github.com/osbuild/bootc-image-builder/bib/internal/imagetypes"
+	"github.com/osbuild/bootc-image-builder/bib/internal/osbuildprogress"
 	"github.com/osbuild/bootc-image-builder/bib/internal/setup"
 	"github.com/osbuild/bootc-image-builder/bib/internal/source"
 	"github.com/osbuild/bootc-image-builder/bib/internal/util"
@@ -383,6 +384,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	osbuildStore, _ := cmd.Flags().GetString("store")
 	outputDir, _ := cmd.Flags().GetString("output")
 	targetArch, _ := cmd.Flags().GetString("target-arch")
+	progress, _ := cmd.Flags().GetString("progress")
 
 	logrus.Debug("Validating environment")
 	if err := setup.Validate(targetArch); err != nil {
@@ -453,7 +455,12 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		osbuildEnv = append(osbuildEnv, envVars...)
 	}
 
-	_, err = osbuild.RunOSBuild(mf, osbuildStore, outputDir, exports, nil, osbuildEnv, false, os.Stderr)
+	switch progress {
+	case "text":
+		err = osbuildprogress.RunOSBuild(mf, osbuildStore, outputDir, exports, osbuildEnv)
+	default:
+		_, err = osbuild.RunOSBuild(mf, osbuildStore, outputDir, exports, nil, osbuildEnv, false, os.Stderr)
+	}
 	if err != nil {
 		return fmt.Errorf("cannot run osbuild: %w", err)
 	}
@@ -607,7 +614,8 @@ func buildCobraCmdline() (*cobra.Command, error) {
 	buildCmd.Flags().String("aws-region", "", "target region for AWS uploads (only for type=ami)")
 	buildCmd.Flags().String("chown", "", "chown the ouput directory to match the specified UID:GID")
 	buildCmd.Flags().String("output", ".", "artifact output directory")
-	buildCmd.Flags().String("progress", "text", "type of progress bar to use")
+	// XXX: make this a proper type
+	buildCmd.Flags().String("progress", "none", "type of progress bar to use")
 	buildCmd.Flags().String("store", "/store", "osbuild store for intermediate pipeline trees")
 	// flag rules
 	for _, dname := range []string{"output", "store", "rpmmd"} {

--- a/bib/internal/osbuildprogress/progress.go
+++ b/bib/internal/osbuildprogress/progress.go
@@ -174,6 +174,10 @@ func RunOSBuild(manifest []byte, store, outputDirectory string, exports, extraEn
 		"--monitor-fd=3",
 		"-",
 	)
+	for _, export := range exports {
+		cmd.Args = append(cmd.Args, "--export", export)
+	}
+
 	cmd.Env = append(os.Environ(), extraEnv...)
 	cmd.Stdin = bytes.NewBuffer(manifest)
 	cmd.Stderr = os.Stderr
@@ -181,11 +185,8 @@ func RunOSBuild(manifest []byte, store, outputDirectory string, exports, extraEn
 	// exported here
 	cmd.Stdout = nil
 	cmd.ExtraFiles = []*os.File{wp}
-	go AttachProgress(wg, rp, os.Stdout)
 
-	for _, export := range exports {
-		cmd.Args = append(cmd.Args, "--export", export)
-	}
+	go AttachProgress(wg, rp, os.Stdout)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("error starting osbuild: %v", err)
 	}

--- a/bib/internal/osbuildprogress/progress.go
+++ b/bib/internal/osbuildprogress/progress.go
@@ -1,0 +1,176 @@
+package osbuildprogress
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type OsbuildJsonProgress struct {
+	ID      string `json:"id"`
+	Context struct {
+		Origin   string `json:"origin"`
+		Pipeline struct {
+			Name  string `json:"name"`
+			Stage struct {
+				Name string `json:"name"`
+				ID   string `json:"id"`
+			} `json:"stage"`
+			ID string `json:"id"`
+		} `json:"pipeline"`
+	} `json:"context"`
+	Progress struct {
+		Name  string `json:"name"`
+		Total int    `json:"total"`
+		Done  int    `json:"done"`
+		// XXX: there are currently only two levels but it should be
+		// deeper nested in theory
+		SubProgress struct {
+			Name  string `json:"name"`
+			Total int    `json:"total"`
+			Done  int    `json:"done"`
+			// XXX: in theory this could be more nested but it's not
+
+		} `json:"progress"`
+	} `json:"progress"`
+
+	Message string `json:"message"`
+}
+
+func scanJsonSeq(r io.Reader, ch chan OsbuildJsonProgress) {
+	var progress OsbuildJsonProgress
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		// XXX: use a proper jsonseq reader?
+		line := scanner.Bytes()
+		line = bytes.Trim(line, "\x1e")
+		if err := json.Unmarshal(line, &progress); err != nil {
+			// XXX: provide an invalid lines chan
+			fmt.Fprintf(os.Stderr, "json decode err for line %q: %v\n", line, err)
+			continue
+		}
+		ch <- progress
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		// log error here
+	}
+}
+
+func AttachProgress(r io.Reader, w io.Writer) {
+	var progress OsbuildJsonProgress
+	spinner := []string{"|", "/", "-", "\\"}
+	i := 0
+
+	ch := make(chan OsbuildJsonProgress)
+	go scanJsonSeq(r, ch)
+
+	mainProgress := "unknown"
+	subProgress := ""
+	message := "-"
+
+	contextMap := map[string]string{}
+
+	fmt.Fprintf(w, "\n")
+	for {
+		select {
+		case progress = <-ch:
+			id := progress.Context.Pipeline.ID
+			pipelineName := contextMap[id]
+			if pipelineName == "" {
+				pipelineName = progress.Context.Pipeline.Name
+				contextMap[id] = pipelineName
+			}
+			// XXX: use differentmap?
+			id = "stage-" + progress.Context.Pipeline.Stage.ID
+			stageName := contextMap[id]
+			if stageName == "" {
+				stageName = progress.Context.Pipeline.Stage.Name
+				contextMap[id] = stageName
+			}
+
+			if progress.Progress.Total > 0 {
+				mainProgress = fmt.Sprintf("step: %v [%v/%v]", pipelineName, progress.Progress.Done+1, progress.Progress.Total+1)
+			}
+			// XXX: use context instead of name here too
+			if progress.Progress.SubProgress.Total > 0 {
+				subProgress = fmt.Sprintf("%v [%v/%v]", stageName, progress.Progress.SubProgress.Done+1, progress.Progress.SubProgress.Total+1)
+			}
+
+			// todo: make message more structured in osbuild?
+			// message from the stages themselfs are very noisy
+			// best not to show to the user (only for failures)
+			if progress.Context.Origin == "osbuild.monitor" {
+				message = progress.Message
+			}
+			//message = strings.TrimSpace(strings.SplitN(progress.Message, "\n", 2)[0])
+			// todo: fix in osbuild?
+			/*
+				l := strings.SplitN(message, ":", 2)
+				if len(l) > 1 {
+					message = strings.TrimSpace(l[1])
+				}
+			*/
+			if len(message) > 60 {
+				message = message[:60] + "..."
+			}
+		case <-time.After(200 * time.Millisecond):
+			// nothing
+		}
+
+		// XXX: use real progressbar *or* use helper to get terminal
+		// size for proper length checks etc
+		//
+		// poor man progress, we need multiple progress bars and
+		// a message that keeps getting updated (or maybe not the
+		// message)
+		fmt.Fprintf(w, "\x1b[2KBuilding [%s]\n", spinner[i])
+		fmt.Fprintf(w, "\x1b[2Kstep   : %s\n", mainProgress)
+		if subProgress != "" {
+			fmt.Fprintf(w, "\x1b[2Kmodule : %s\n", strings.TrimPrefix(subProgress, "org.osbuild."))
+		}
+		fmt.Fprintf(w, "\x1b[3Kmessage: %s\n", message)
+		if subProgress != "" {
+			fmt.Fprintf(w, "\x1b[%dA", 4)
+		} else {
+			fmt.Fprintf(w, "\x1b[%dA", 3)
+		}
+		// spin
+		i = (i + 1) % len(spinner)
+	}
+}
+
+// XXX: merge back into images/pkg/osbuild/osbuild-exec.go(?)
+func RunOSBuild(manifest []byte, store, outputDirectory string, exports, extraEnv []string) error {
+	cmd := exec.Command(
+		"osbuild",
+		"--store", store,
+		"--output-directory", outputDirectory,
+		"--monitor=JSONSeqMonitor",
+		"-",
+	)
+	cmd.Env = append(os.Environ(), extraEnv...)
+	cmd.Stdin = bytes.NewBuffer(manifest)
+	cmd.Stderr = os.Stderr
+
+	for _, export := range exports {
+		cmd.Args = append(cmd.Args, "--export", export)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	go AttachProgress(stdout, os.Stdout)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("error starting osbuild: %v", err)
+	}
+	return cmd.Wait()
+}

--- a/bib/internal/osbuildprogress/progress.go
+++ b/bib/internal/osbuildprogress/progress.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/cheggaaa/pb/v3"
 )
 
 type OsbuildJsonProgress struct {
@@ -27,14 +29,14 @@ type OsbuildJsonProgress struct {
 	} `json:"context"`
 	Progress struct {
 		Name  string `json:"name"`
-		Total int    `json:"total"`
-		Done  int    `json:"done"`
+		Total int64  `json:"total"`
+		Done  int64  `json:"done"`
 		// XXX: there are currently only two levels but it should be
 		// deeper nested in theory
 		SubProgress struct {
 			Name  string `json:"name"`
-			Total int    `json:"total"`
-			Done  int    `json:"done"`
+			Total int64  `json:"total"`
+			Done  int64  `json:"done"`
 			// XXX: in theory this could be more nested but it's not
 
 		} `json:"progress"`
@@ -43,7 +45,7 @@ type OsbuildJsonProgress struct {
 	Message string `json:"message"`
 }
 
-func scanJsonSeq(r io.Reader, ch chan OsbuildJsonProgress) {
+func scanJsonSeq(r io.Reader, ch chan OsbuildJsonProgress, errCh chan error) {
 	var progress OsbuildJsonProgress
 
 	scanner := bufio.NewScanner(r)
@@ -53,33 +55,48 @@ func scanJsonSeq(r io.Reader, ch chan OsbuildJsonProgress) {
 		line = bytes.Trim(line, "\x1e")
 		if err := json.Unmarshal(line, &progress); err != nil {
 			// XXX: provide an invalid lines chan
-			fmt.Fprintf(os.Stderr, "json decode err for line %q: %v\n", line, err)
+			errCh <- err
 			continue
 		}
 		ch <- progress
 	}
 	if err := scanner.Err(); err != nil && err != io.EOF {
-		// log error here
+		errCh <- err
 	}
 }
 
 func AttachProgress(r io.Reader, w io.Writer) {
 	var progress OsbuildJsonProgress
-	spinner := []string{"|", "/", "-", "\\"}
-	i := 0
 
 	ch := make(chan OsbuildJsonProgress)
-	go scanJsonSeq(r, ch)
+	errCh := make(chan error)
+	go scanJsonSeq(r, ch, errCh)
 
-	mainProgress := "unknown"
-	subProgress := ""
-	message := "-"
+	lastMessage := "-"
+
+	spinnerPb := pb.New(0)
+	spinnerPb.SetTemplate(`Building [{{ (cycle . "|" "/" "-" "\\") }}]`)
+	mainPb := pb.New(0)
+	progressBarTmplFmt := `[{{ counters . }}] %s: {{ string . "prefix" }} {{ bar .}} {{ percent . }}`
+	mainPb.SetTemplateString(fmt.Sprintf(progressBarTmplFmt, "step"))
+	subPb := pb.New(0)
+	subPb.SetTemplateString(fmt.Sprintf(progressBarTmplFmt, "module"))
+	msgPb := pb.New(0)
+	msgPb.SetTemplate(`last msg: {{ string . "msg" }}`)
+
+	pool, err := pb.StartPool(spinnerPb, mainPb, subPb, msgPb)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "progress failed: %v\n", err)
+		return
+	}
 
 	contextMap := map[string]string{}
 
-	fmt.Fprintf(w, "\n")
 	for {
 		select {
+		case err := <-errCh:
+			fmt.Fprintf(os.Stderr, "error: %v", err)
+			break
 		case progress = <-ch:
 			id := progress.Context.Pipeline.ID
 			pipelineName := contextMap[id]
@@ -96,54 +113,38 @@ func AttachProgress(r io.Reader, w io.Writer) {
 			}
 
 			if progress.Progress.Total > 0 {
-				mainProgress = fmt.Sprintf("step: %v [%v/%v]", pipelineName, progress.Progress.Done+1, progress.Progress.Total+1)
+				mainPb.SetTotal(progress.Progress.Total + 1)
+				mainPb.SetCurrent(progress.Progress.Done + 1)
+				mainPb.Set("prefix", pipelineName)
 			}
 			// XXX: use context instead of name here too
 			if progress.Progress.SubProgress.Total > 0 {
-				subProgress = fmt.Sprintf("%v [%v/%v]", stageName, progress.Progress.SubProgress.Done+1, progress.Progress.SubProgress.Total+1)
+				subPb.SetTotal(progress.Progress.SubProgress.Total + 1)
+				subPb.SetCurrent(progress.Progress.SubProgress.Done + 1)
+				subPb.Set("prefix", strings.TrimPrefix(stageName, "org.osbuild."))
 			}
 
 			// todo: make message more structured in osbuild?
 			// message from the stages themselfs are very noisy
 			// best not to show to the user (only for failures)
 			if progress.Context.Origin == "osbuild.monitor" {
-				message = progress.Message
+				lastMessage = progress.Message
 			}
-			//message = strings.TrimSpace(strings.SplitN(progress.Message, "\n", 2)[0])
-			// todo: fix in osbuild?
 			/*
-				l := strings.SplitN(message, ":", 2)
+				// todo: fix in osbuild?
+				lastMessage = strings.TrimSpace(strings.SplitN(progress.Message, "\n", 2)[0])
+				l := strings.SplitN(lastMessage, ":", 2)
 				if len(l) > 1 {
-					message = strings.TrimSpace(l[1])
+					lastMessage = strings.TrimSpace(l[1])
 				}
 			*/
-			if len(message) > 60 {
-				message = message[:60] + "..."
-			}
+			msgPb.Set("msg", lastMessage)
+
 		case <-time.After(200 * time.Millisecond):
 			// nothing
 		}
-
-		// XXX: use real progressbar *or* use helper to get terminal
-		// size for proper length checks etc
-		//
-		// poor man progress, we need multiple progress bars and
-		// a message that keeps getting updated (or maybe not the
-		// message)
-		fmt.Fprintf(w, "\x1b[2KBuilding [%s]\n", spinner[i])
-		fmt.Fprintf(w, "\x1b[2Kstep   : %s\n", mainProgress)
-		if subProgress != "" {
-			fmt.Fprintf(w, "\x1b[2Kmodule : %s\n", strings.TrimPrefix(subProgress, "org.osbuild."))
-		}
-		fmt.Fprintf(w, "\x1b[3Kmessage: %s\n", message)
-		if subProgress != "" {
-			fmt.Fprintf(w, "\x1b[%dA", 4)
-		} else {
-			fmt.Fprintf(w, "\x1b[%dA", 3)
-		}
-		// spin
-		i = (i + 1) % len(spinner)
 	}
+	pool.Stop()
 }
 
 // XXX: merge back into images/pkg/osbuild/osbuild-exec.go(?)
@@ -172,5 +173,6 @@ func RunOSBuild(manifest []byte, store, outputDirectory string, exports, extraEn
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("error starting osbuild: %v", err)
 	}
+	// XXX: add WaitGroup
 	return cmd.Wait()
 }


### PR DESCRIPTION
This adds a new `bootc-image-builder` mode that makes use of the
osbuild json-seq progress information. It will display some
user friendly progress information. It can be tested via:
```sh
$ cd bib/cmd/bootc-image-builder
$ echo '{}' > config.json
$ go build && sudo ./bootc-image-builder build --progress=text --store /var/tmp/osbuild-store --config config.json quay.io/centos-bootc/centos-bootc:stream9
```
It looks like this right now:
```
Building manifest-qcow2.json
Building [|]                                                                    
[4 / 8] step: image [------------------------->_________________________] 50.00%
[7 / 11] module: bootc.install-to-filesystem [---------------->_________] 63.64%
last msg: Starting module org.osbuild.bootc.install-to-filesystem              
```

It uses `chegggaaa/pb/v3`  - but there are still open questions about the message output and error handling.

Draft because:
- error handling is very sketchy, if something in the build fails the user gets a "failed" message but no context, we need to either make sure osbuild progress has a concept of an error and dump the entire output of the stage into this (as errors details tend to be inside the failed stage (this needs some osbuild work)
- ~no syncronisation between cmd.Wait() and the progress reader reading output, this also needs to get fixed via e.g. a waitgroup so that both the cmd needs to finish and the stdout read gets an EOF before we continue as otherwise the last progress messages may get lost~
- tests (obviously) but that is tricky for progress, definitely some of the failure handling
- ~osbuild currently prints random non-json at the end of a run, we need to fix that or deal with it gracefully~
- Naming of things like pipelines/source and stages
- ~Needs https://github.com/osbuild/osbuild/pull/1826 for correct reporting~
6. ... ?