### PR TITLE
test: rework how test cases are represented/generated

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from testcases import TestCase
+
 
 def pytest_addoption(parser):
     parser.addoption("--force-aws-upload", action="store_true", default=False,
@@ -10,3 +12,11 @@ def pytest_addoption(parser):
 @pytest.fixture(name="force_aws_upload", scope="session")
 def force_aws_upload_fixture(request):
     return request.config.getoption("--force-aws-upload")
+
+
+# see https://hackebrot.github.io/pytest-tricks/param_id_func/ and
+# https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_make_parametrize_id
+def pytest_make_parametrize_id(config, val):
+    if isinstance(val, TestCase):
+        return f"{val}"
+    return None

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -260,13 +260,6 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
         if tc.local:
             cmd.extend(["-v", "/var/lib/containers/storage:/var/lib/containers/storage"])
 
-        # fedora has no default roofs, pick "brfs" for testing here
-        # TODO: make part of testcase instead of hacking it in here
-        if "fedora" in container_ref:
-            rootfs_args = ["--rootfs", "btrfs"]
-        else:
-            rootfs_args = []
-
         cmd.extend([
             *creds_args,
             build_container,

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -33,10 +33,7 @@ class TestCase:
     def rootfs_args(self):
         # fedora has no default rootfs so it must be specified
         if "fedora-bootc" in self.container_ref:
-            # TODO: switch to "btrfs" once
-            # https://github.com/osbuild/bootc-image-builder/pull/439
-            # is merged
-            return ["--rootfs", "ext4"]
+            return ["--rootfs", "btrfs"]
         return []
 
     def __str__(self):


### PR DESCRIPTION
The old way of generating test cases was via strings that would use a `,` to differenciate between various parameters like container_ref or image_type.

With the adding of the rootfs this becomes unwieldy (arguable it was unwieldy already and now it's unentable). This commit introduces a proper "TestCase" class that makes generating and reading the test cases a lot eaiser (IMHO).

Note that this was prompted because of PR#439 where we want to make the rootfs tests on fedora "btrfs".

[draft until tests are green, there is a lot of churn in here :)]