### PR TITLE
README.md: fix user customisations example

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,17 +310,19 @@ Example:
 
 ```json
 {
-  "user": [
-    {
-      "name": "alice",
-      "password": "bob",
-      "key": "ssh-rsa AAA ... user@email.com",
-      "groups": [
-        "wheel",
-        "admins"
-      ]
-    }
-  ]
+  "customizations": {
+    "user": [
+      {
+        "name": "alice",
+        "password": "bob",
+        "key": "ssh-rsa AAA ... user@email.com",
+        "groups": [
+          "wheel",
+          "admins"
+        ]
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
The example in the README does not actually work and needs a `customizations` key. Thanks to Charlie Drage for finding this!

Closes: https://github.com/osbuild/bootc-image-builder/issues/534