### PR TITLE
Enable new Anaconda modules: Users, Services, and Security (RHEL-49499)

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -242,7 +242,11 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 		img.Kickstart.KernelOptionsAppend = append(img.Kickstart.KernelOptionsAppend, kopts.Append)
 	}
 	img.Kickstart.NetworkOnBoot = true
-	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")
+	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules,
+		"org.fedoraproject.Anaconda.Modules.Users",
+		"org.fedoraproject.Anaconda.Modules.Services",
+		"org.fedoraproject.Anaconda.Modules.Security",
+	)
 
 	img.Kickstart.OSTree = &kickstart.OSTree{
 		OSName: "default",

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -242,12 +242,7 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 		img.Kickstart.KernelOptionsAppend = append(img.Kickstart.KernelOptionsAppend, kopts.Append)
 	}
 	img.Kickstart.NetworkOnBoot = true
-	// XXX: this should really be done by images, the consumer should not
-	// need to know these details. so once images is fixed drop it here
-	// again.
-	if len(img.Kickstart.Users) > 0 || len(img.Kickstart.Groups) > 0 {
-		img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")
-	}
+	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")
 
 	img.Kickstart.OSTree = &kickstart.OSTree{
 		OSName: "default",


### PR DESCRIPTION
**bib: enable Anaconda Users module for ISO**

We generally only enable the Users module in ISOs when a user is
configured because we want the installation to be fully automatic /
unattended and, in the general case, Anaconda will block and wait for
user input if no users are configured.  However, since we always add
`rootpw --lock` to our kickstart file, this satisfies Anaconda's user
configuration rule and the installation proceeds without blocking.

Enabling the Users module unconditionally allows users to include user
configuration when they inject their own kickstart files.

---

**bib: enable Anaconda Services and Security modules**

These modules don't affect any existing functionality but enable more
kickstart verbs for users that want to use them.

---
