### PR TITLE
Switch to BurntSushi/toml and error out on unknown toml keys

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -3,11 +3,11 @@ module github.com/osbuild/bootc-image-builder/bib
 go 1.21
 
 require (
+	github.com/BurntSushi/toml v1.4.0
 	github.com/aws/aws-sdk-go v1.55.3
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/google/uuid v1.6.0
 	github.com/osbuild/images v0.72.0
-	github.com/pelletier/go-toml v1.9.5
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
@@ -19,7 +19,6 @@ require (
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
-	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.3 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -230,8 +230,6 @@ github.com/osbuild/images v0.72.0 h1:WKRXokWCpkS6zusc2yadXbW5jQD4cNvBMHZUV/8L4jM
 github.com/osbuild/images v0.72.0/go.mod h1:McWtOOsi/2gH2J4tQ8Vnvg+O3jVf44XIj3jUWJZt47E=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
-github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
-github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/bib/internal/buildconfig/config.go
+++ b/bib/internal/buildconfig/config.go
@@ -59,9 +59,15 @@ func decodeTomlBuildConfig(r io.Reader, what string) (*BuildConfig, error) {
 	dec := toml.NewDecoder(r)
 
 	var conf BuildConfig
-	if _, err := dec.Decode(&conf); err != nil {
+	metadata, err := dec.Decode(&conf)
+	if err != nil {
 		return nil, fmt.Errorf("cannot decode %q: %w", what, err)
 	}
+
+	if len(metadata.Undecoded()) > 0 {
+		return nil, fmt.Errorf("cannot decode %q: unknown keys found: %v", what, metadata.Undecoded())
+	}
+
 	return &conf, nil
 }
 

--- a/bib/internal/buildconfig/config.go
+++ b/bib/internal/buildconfig/config.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pelletier/go-toml"
+	"github.com/BurntSushi/toml"
 	"github.com/sirupsen/logrus"
 
 	"github.com/osbuild/images/pkg/blueprint"
@@ -59,7 +59,7 @@ func decodeTomlBuildConfig(r io.Reader, what string) (*BuildConfig, error) {
 	dec := toml.NewDecoder(r)
 
 	var conf BuildConfig
-	if err := dec.Decode(&conf); err != nil {
+	if _, err := dec.Decode(&conf); err != nil {
 		return nil, fmt.Errorf("cannot decode %q: %w", what, err)
 	}
 	return &conf, nil

--- a/bib/internal/buildconfig/config_test.go
+++ b/bib/internal/buildconfig/config_test.go
@@ -132,3 +132,28 @@ func TestReadLegacyJSONConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBuildConfig, cfg)
 }
+
+func TestTomlUnknownKeysError(t *testing.T) {
+	fakeUserCnfPath := makeFakeConfig(t, "config.toml", `
+[[birds]]
+name = "toucan"
+`)
+	_, err := buildconfig.ReadWithFallback(fakeUserCnfPath)
+
+	assert.ErrorContains(t, err, "unknown keys found: [birds birds.name]")
+}
+
+func TestJsonUnknownKeysError(t *testing.T) {
+	fakeUserCnfPath := makeFakeConfig(t, "config.json", `
+{
+  "birds": [
+	{
+	  "name": "toucan"
+	}
+  ]
+}
+`)
+	_, err := buildconfig.ReadWithFallback(fakeUserCnfPath)
+
+	assert.ErrorContains(t, err, `json: unknown field "birds"`)
+}


### PR DESCRIPTION
This pull request includes two changes. First, it switches from `pelletier/go-toml` to `BurntSushi/toml` in the `bib` module. This change removes a dependency and aligns with the use of `BurntSushi` elsewhere in the codebase. Second, it adds error handling for unknown toml keys in the `buildconfig` module. This change improves clarity and prevents confusion when using older versions of `bib` with recent customizations.