### PR TITLE
bib: Add support for s390x architecture

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -138,6 +138,13 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 				QCOW2Compat: "1.1",
 			},
 		}
+	case arch.ARCH_S390X:
+		img.Platform = &platform.S390X{
+			BasePlatform: platform.BasePlatform{
+				QCOW2Compat: "1.1",
+			},
+			Zipl: true,
+		}
 	}
 
 	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {

--- a/bib/cmd/bootc-image-builder/partition_tables.go
+++ b/bib/cmd/bootc-image-builder/partition_tables.go
@@ -118,4 +118,36 @@ var partitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
+	arch.ARCH_S390X.String(): disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size: 1 * GibiByte,
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: BootOptions,
+					FSTabFreq:    1,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 2 * GibiByte,
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: RootOptions,
+					FSTabFreq:    1,
+					FSTabPassNo:  1,
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
This patch adds support for s390x platform and its disk partition table layout.