### PR TITLE
include subscription-manager to fix integration with Konflux

### DIFF
--- a/package-requires.txt
+++ b/package-requires.txt
@@ -12,3 +12,9 @@ qemu-img
 
 # rpm-ostree wants these for packages
 selinux-policy-targeted distribution-gpg-keys
+
+# Konflux mounts in /etc/pki/entitlement instead of /run/secrets.
+# This is not how we intended bib to work, but it works if subscription-manager is in bib.
+# Include it temporarily, before we find a better long-term solution.
+# See https://github.com/konflux-ci/build-definitions/blob/f3ac40bbc0230eccb8d98a4d54dabd55a4943c5d/task/build-vm-image/0.1/build-vm-image.yaml#L198
+subscription-manager


### PR DESCRIPTION
Konflux mounts in /etc/pki/entitlement instead of /run/secrets. This is not how we intended bib to work, but it works if subscription-manager is in bib. Include it temporarily, before we find a better long-term solution.

See https://github.com/konflux-ci/build-definitions/blob/f3ac40bbc0230eccb8d98a4d54dabd55a4943c5d/task/build-vm-image/0.1/build-vm-image.yaml#L198