### PR TITLE
konflux: add missing deprecated-base-image-check params

### DIFF
--- a/.tekton/bootc-image-builder-push.yaml
+++ b/.tekton/bootc-image-builder-push.yaml
@@ -364,6 +364,10 @@ spec:
         params:
           - name: BASE_IMAGES_DIGESTS
             value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
+          - name: IMAGE_URL
+            value: $(tasks.build-container.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
         taskRef:
           params:
             - name: name


### PR DESCRIPTION
This is needed in order to migrate to 0.4, we somehow did the change
only in the pull request pipeline.