### PR TITLE
Use dnf in the container to install osbuild-depsolve-dnf instead of copying a file

### DIFF
--- a/bib/internal/container/container.go
+++ b/bib/internal/container/container.go
@@ -83,9 +83,14 @@ func (c *Container) Stop() error {
 	if output, err := exec.Command("podman", "stop", c.id).CombinedOutput(); err != nil {
 		return fmt.Errorf("stopping %s container failed: %w\noutput:\n%s", c.id, err, output)
 	}
-	// when the container is stopped by podman it will not honor the "--rm"
-	// that was passed in `New()` so manually remove the container here.
+	// when the container is stopped by podman it may not honor the "--rm"
+	// that was passed in `New()` so manually remove the container here if it is still available
 	if output, err := exec.Command("podman", "rm", c.id).CombinedOutput(); err != nil {
+		// This is ok, container has already been removed
+		if strings.Contains(string(output), "no container with ID or name") {
+			return nil
+		}
+
 		return fmt.Errorf("removing %s container failed: %w\noutput:\n%s", c.id, err, output)
 	}
 

--- a/bib/internal/container/container.go
+++ b/bib/internal/container/container.go
@@ -136,6 +136,17 @@ func (c *Container) InitDNF() error {
 	return nil
 }
 
+// InstallPackages uses dnf in the container to install packages
+func (c *Container) InstallPackages(pkgs []string) error {
+	args := []string{"exec", c.id, "dnf", "install", "-y"}
+	args = append(args, pkgs...)
+	if output, err := exec.Command("podman", args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("installing packages in %s container failed: %w\noutput:\n%s", c.id, err, string(output))
+	}
+
+	return nil
+}
+
 // DefaultRootfsType returns the default rootfs type (e.g. "ext4") as
 // specified by the bootc container install configuration. An empty
 // string is valid and means the container sets no default.

--- a/bib/internal/container/container_test.go
+++ b/bib/internal/container/container_test.go
@@ -123,6 +123,27 @@ func TestCopyInto(t *testing.T) {
 	require.Equal(t, "Hello, world!", string(testfileContent))
 }
 
+func TestInstallPackages(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("skipping test; not running as root")
+	}
+
+	c, err := New(testingImage)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err = c.Stop()
+		assert.NoError(t, err)
+	})
+
+	err = c.InstallPackages([]string{"osbuild-depsolve-dnf"})
+	require.NoError(t, err)
+
+	root := c.Root()
+	testfileInContainer := path.Join(root, "usr/libexec/osbuild-depsolve-dnf")
+	_, err = os.ReadFile(testfileInContainer)
+	require.NoError(t, err)
+}
+
 func makeFakePodman(t *testing.T, content string) {
 	tmpdir := t.TempDir()
 	t.Setenv("PATH", tmpdir+":"+os.Getenv("PATH"))

--- a/bib/internal/container/container_test.go
+++ b/bib/internal/container/container_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testingImage = "registry.access.redhat.com/ubi9-micro:latest"
+const testingImage = "quay.io/centos/centos:stream9"
 
 type containerInfo struct {
 	State string `json:"State"`
@@ -77,7 +77,7 @@ func TestNew(t *testing.T) {
 	osRelease, err := os.ReadFile(path.Join(root, "etc/os-release"))
 	require.NoError(t, err)
 
-	assert.Contains(t, string(osRelease), `ID="rhel"`)
+	assert.Contains(t, string(osRelease), `ID="centos"`)
 }
 
 func TestReadFile(t *testing.T) {
@@ -94,7 +94,7 @@ func TestReadFile(t *testing.T) {
 
 	content, err := c.ReadFile("/etc/os-release")
 	require.NoError(t, err)
-	require.Contains(t, string(content), `ID="rhel"`)
+	require.Contains(t, string(content), `ID="centos"`)
 }
 
 func TestCopyInto(t *testing.T) {
@@ -130,6 +130,7 @@ func makeFakePodman(t *testing.T, content string) {
 	err := os.WriteFile(filepath.Join(tmpdir, "podman"), []byte(content), 0755)
 	assert.NoError(t, err)
 }
+
 func TestNewFakedUnhappy(t *testing.T) {
 	fakePodman := `#!/bin/sh
 if [ "$1" = "mount" ]; then


### PR DESCRIPTION
Includes some changes to tests.