### PR TITLE
bib: drop hardcoding disk UUID

### DIFF
--- a/bib/cmd/bootc-image-builder/partition_tables.go
+++ b/bib/cmd/bootc-image-builder/partition_tables.go
@@ -23,7 +23,6 @@ const (
 
 var partitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
@@ -75,7 +74,6 @@ var partitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID: "0xc1748067",
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
@@ -119,7 +117,6 @@ var partitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_S390X.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{

--- a/bib/cmd/bootc-image-builder/partition_tables.go
+++ b/bib/cmd/bootc-image-builder/partition_tables.go
@@ -29,15 +29,12 @@ var partitionTables = distro.BasePartitionTableMap{
 				Size:     1 * MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
 				Size: 501 * MebiByte,
 				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
 					Mountpoint:   "/boot/efi",
 					Label:        "EFI-SYSTEM",
 					FSTabOptions: "umask=0077,shortname=winnt",
@@ -48,7 +45,6 @@ var partitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 1 * GibiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -61,7 +57,6 @@ var partitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 2 * GibiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",
@@ -82,7 +77,6 @@ var partitionTables = distro.BasePartitionTableMap{
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
 					Mountpoint:   "/boot/efi",
 					Label:        "EFI-SYSTEM",
 					FSTabOptions: "umask=0077,shortname=winnt",
@@ -122,7 +116,6 @@ var partitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 1 * GibiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -135,7 +128,6 @@ var partitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 2 * GibiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",
@@ -148,7 +140,6 @@ var partitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_PPC64LE.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
@@ -159,7 +150,6 @@ var partitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 500 * MebiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -172,7 +162,6 @@ var partitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 2 * GibiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",


### PR DESCRIPTION
The current parition_tables.go hardcodes the UUID for the PartitionTable. This is undesired. Drop it so that images generates it automatically and randomly for us.

A similar change is probably wanted for images itself and the parition UUIDs.

[draft as this needs discussion and at lest one test

Also volumeid for vfat needs fixing 