### PR TITLE
bib: fix unit test for TestReadUserConfigErrorWrongFormat

### DIFF
--- a/bib/internal/buildconfig/config_test.go
+++ b/bib/internal/buildconfig/config_test.go
@@ -91,7 +91,7 @@ func TestReadUserConfigErrorWrongFormat(t *testing.T) {
 		expectedErr    string
 	}{
 		// wrong content, json in a toml file and vice-versa
-		{"config.toml", fakeConfigJSON, "parsing error"},
+		{"config.toml", fakeConfigJSON, "cannot decode"},
 		{"config.json", fakeConfigToml, "cannot decode"},
 	} {
 		fakeCnfPath := makeFakeConfig(t, tc.fname, tc.content)


### PR DESCRIPTION
When moving to the new toml reader the
TestReadUserConfigErrorWrongFormat test broke. This trival commit fixes it.

C.f. https://github.com/osbuild/bootc-image-builder/pull/549