### PR TITLE
README: include short section on reporting bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,14 @@ The contents of the file `$(pwd)/wheel-passwordless-sudo` should be
 %wheel ALL=(ALL) NOPASSWD: ALL
 ```
 
+## Reporting bugs
+
+Please report bugs to the [Bug Tracker](https://github.com/osbuild/bootc-image-builder/issues) and include instructions to reproduce and the output of:
+```
+$ sudo podman run --rm -it --entrypoint=/usr/bin/bootc-image-builder \
+    quay.io/centos-bootc/bootc-image-builder:latest version
+```
+
 ## 📊 Project
 
 - **Website**: <https://www.osbuild.org>


### PR DESCRIPTION
Also include hint about how to use `bootc-image-builder version` so that users can report what version they are using.