### PR TITLE
Skip rootfs handling when building ISOs

### DIFF
--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -60,7 +60,6 @@ def test_iso_manifest_smoke(build_container, tc):
         "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         "manifest",
-        *tc.bib_rootfs_args(),
         "--type=anaconda-iso", f"{tc.container_ref}",
     ])
     manifest = json.loads(output)


### PR DESCRIPTION
The ISO build doesn't require the rootfs configuration from the image,
so there is no need to read it from the container nor to require the
flag when it is missing.

Closes #494.
