### PR TITLE
partitions: Switch aarch64 to GPT, fully deduplicate

### DIFF
--- a/bib/cmd/bootc-image-builder/partition_tables.go
+++ b/bib/cmd/bootc-image-builder/partition_tables.go
@@ -21,9 +21,69 @@ const (
 	RootOptions = "ro"
 )
 
+// diskUuidOfUnknownOrigin is used by default for disk images,
+// picked by someone in the past for unknown reasons. More in
+// e.g. https://github.com/osbuild/bootc-image-builder/pull/568 and
+// https://github.com/osbuild/images/pull/823
+const diskUuidOfUnknownOrigin = "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
+
+// efiPartition defines the default ESP. See also
+// https://en.wikipedia.org/wiki/EFI_system_partition
+var efiPartition = disk.Partition{
+	Size: 501 * MebiByte,
+	Type: disk.EFISystemPartitionGUID,
+	UUID: disk.EFISystemPartitionUUID,
+	Payload: &disk.Filesystem{
+		Type:         "vfat",
+		UUID:         disk.EFIFilesystemUUID,
+		Mountpoint:   "/boot/efi",
+		Label:        "EFI-SYSTEM",
+		FSTabOptions: "umask=0077,shortname=winnt",
+		FSTabFreq:    0,
+		FSTabPassNo:  2,
+	},
+}
+
+// bootPartition defines a distinct filesystem for /boot
+// which is needed for e.g. LVM or LUKS when using GRUB
+// (which this project doesn't support today...)
+// See also https://github.com/containers/bootc/pull/529/commits/e5548d8765079171e6ed39a3ab0479bc8681a1c9
+var bootPartition = disk.Partition{
+	Size: 1 * GibiByte,
+	Type: disk.FilesystemDataGUID,
+	UUID: disk.FilesystemDataUUID,
+	Payload: &disk.Filesystem{
+		Type:         "ext4",
+		Mountpoint:   "/boot",
+		Label:        "boot",
+		FSTabOptions: BootOptions,
+		FSTabFreq:    1,
+		FSTabPassNo:  2,
+	},
+}
+
+// rootPartition holds the root filesystem; however note
+// that while the type here defines "ext4" because the data
+// type requires something there, in practice we pull
+// the rootfs type from the container image by default.
+// See https://containers.github.io/bootc/bootc-install.html
+var rootPartition = disk.Partition{
+	Size: 2 * GibiByte,
+	Type: disk.FilesystemDataGUID,
+	UUID: disk.RootPartitionUUID,
+	Payload: &disk.Filesystem{
+		Type:         "ext4",
+		Label:        "root",
+		Mountpoint:   "/",
+		FSTabOptions: RootOptions,
+		FSTabFreq:    1,
+		FSTabPassNo:  1,
+	},
+}
+
 var partitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		UUID: diskUuidOfUnknownOrigin,
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
@@ -32,126 +92,30 @@ var partitionTables = distro.BasePartitionTableMap{
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
-			{
-				Size: 501 * MebiByte,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "umask=0077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Size: 1 * GibiByte,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: BootOptions,
-					FSTabFreq:    1,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Size: 2 * GibiByte,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: RootOptions,
-					FSTabFreq:    1,
-					FSTabPassNo:  1,
-				},
-			},
+			efiPartition,
+			bootPartition,
+			rootPartition,
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID: "0xc1748067",
-		Type: "dos",
+		UUID: diskUuidOfUnknownOrigin,
+		Type: "gpt",
 		Partitions: []disk.Partition{
-			{
-				Size:     501 * MebiByte,
-				Type:     "06",
-				Bootable: true,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "umask=0077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Size: 1 * GibiByte,
-				Type: "83",
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: BootOptions,
-					FSTabFreq:    1,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Size: 2569 * MebiByte,
-				Type: "83",
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: RootOptions,
-					FSTabFreq:    1,
-					FSTabPassNo:  1,
-				},
-			},
+			efiPartition,
+			bootPartition,
+			rootPartition,
 		},
 	},
 	arch.ARCH_S390X.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		UUID: diskUuidOfUnknownOrigin,
 		Type: "gpt",
 		Partitions: []disk.Partition{
-			{
-				Size: 1 * GibiByte,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: BootOptions,
-					FSTabFreq:    1,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Size: 2 * GibiByte,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: RootOptions,
-					FSTabFreq:    1,
-					FSTabPassNo:  1,
-				},
-			},
+			bootPartition,
+			rootPartition,
 		},
 	},
 	arch.ARCH_PPC64LE.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		UUID: diskUuidOfUnknownOrigin,
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
@@ -159,32 +123,8 @@ var partitionTables = distro.BasePartitionTableMap{
 				Type:     disk.PRePartitionGUID,
 				Bootable: true,
 			},
-			{
-				Size: 500 * MebiByte,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: BootOptions,
-					FSTabFreq:    1,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Size: 2 * GibiByte,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
-				Payload: &disk.Filesystem{
-					Type:         "ext4",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: RootOptions,
-					FSTabFreq:    1,
-					FSTabPassNo:  1,
-				},
-			},
+			bootPartition,
+			rootPartition,
 		},
 	},
 }


### PR DESCRIPTION
Closes: https://github.com/osbuild/bootc-image-builder/issues/551

There was a fair amount of copy-paste even when we just had aarch64+x86_64, the addition of duplicate bootfs/rootfs definitions for ppc64le+s390x is a strong motivation to finally define shared constants.

I also factored out a shared `const` with some comments for the disk UUID that will save someone some time wondering about it later (this textually but not logically conflicts with https://github.com/osbuild/bootc-image-builder/pull/568 but I think this makes sense to land first).