### PR TITLE
bib: switch arch64 back from "gpt" to "dos" to unbreak all Pis with older firmware

### DIFF
--- a/bib/cmd/bootc-image-builder/partition_tables.go
+++ b/bib/cmd/bootc-image-builder/partition_tables.go
@@ -25,7 +25,10 @@ const (
 // picked by someone in the past for unknown reasons. More in
 // e.g. https://github.com/osbuild/bootc-image-builder/pull/568 and
 // https://github.com/osbuild/images/pull/823
-const diskUuidOfUnknownOrigin = "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
+const (
+	diskUuidOfUnknownOrigin    = "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
+	dosDiskUiidOfUnknownOrigin = "0xc1748067"
+)
 
 // efiPartition defines the default ESP. See also
 // https://en.wikipedia.org/wiki/EFI_system_partition
@@ -99,7 +102,7 @@ var partitionTables = distro.BasePartitionTableMap{
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: diskUuidOfUnknownOrigin,
-		Type: disk.PT_GPT,
+		Type: disk.PT_DOS,
 		Partitions: []disk.Partition{
 			efiPartition,
 			bootPartition,


### PR DESCRIPTION
Today I learned that this change to move to "gpt" does not only affect RPi3 but also newer PIs that have not updated their firmware yet. This commit moves back to "dos" for maximum compatibility.

Parallel to this we should IMHO ASAP support a default partition table inside the container (e.g. via /blueprint.json and advanced partitioning there) that is then read by bib and applied so that we can be maximum compatible. Unti lthat is done IMHO the default should optimize for the 90% users which I think is the RPi on aarch64.

When reviewing https://github.com/osbuild/bootc-image-builder/pull/582 I was a bit too enthusiastic about the de-dup (which I totally love) and overlooked that it also switches the default partition type to "gpt" on aarch. This has ramifications for the pi3 that does not support gpt. Given that the pi3 was released in 2016 and the pi4 is 2019 it is maybe okay to just not support the pi3 but I wanted to open this to make sure it's a conscious decision - alternatively we could do smarter stuff and get the partition table from the container and leave it to the container to decide what they want to support.

