### PR TITLE
Containerfile: copy the entire "." dir into /build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,10 +4,9 @@ COPY bib/go.mod bib/go.sum /build/bib/
 ARG GOPROXY=https://proxy.golang.org,direct
 RUN go env -w GOPROXY=$GOPROXY
 RUN cd /build/bib && go mod download
-COPY build.sh /build
-COPY bib /build/bib
-# the ".git" dir will allow go build to automatically include build info
-COPY .git /build/.git
+# Copy the entire dir to avoid having to conditionally include ".git" as that
+# will not be available when tests are run under tmt
+COPY . /build
 WORKDIR /build
 RUN ./build.sh
 

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -560,7 +560,11 @@ func cmdVersion(_ *cobra.Command, _ []string) error {
 			break
 		}
 	}
-	fmt.Printf("revision: %s\n", gitRev[:7])
+	if gitRev != "" {
+		fmt.Printf("revision: %s\n", gitRev[:7])
+	} else {
+		fmt.Printf("revision: unknown\n")
+	}
 	return nil
 }
 

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -163,7 +163,14 @@ def test_bib_version(tmp_path, container_storage, build_fake_container):
         build_fake_container,
         "version",
     ], check=True, capture_output=True, text=True)
-    needle = "revision: "
+
+    expected_rev = "unknown"
+    git_res = subprocess.run(
+        ["git", "describe", "--always"],
+        capture_output=True, text=True, check=False)
+    if git_res.returncode == 0:
+        expected_rev = git_res.stdout.strip()
+    needle = f"revision: {expected_rev}"
     assert needle in res.stdout
 
 


### PR DESCRIPTION
When `tmt` runs it will not include the `.git` dir when it prepares
the source. This was breaking the tmt tests. This commit just makes
the containerfile copy the entire current working dir so that we
get `.git` if it's there or it is skipped otherwise.

Closes: https://github.com/osbuild/bootc-image-builder/issues/583
