### PR TITLE
Support configuring Anaconda modules for ISOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,66 @@ The equivalent in json would be:
 Note that bootc-image-builder will automatically add the command that installs the container image (`ostreecontainer ...`), so this line or any line that conflicts with it should not be included. See the relevant [Kickstart documentation](https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#ostreecontainer) for more information.
 No other kickstart commands are added by bootc-image-builder in this case, so it is the responsibility of the user to provide all other commands (for example, for partitioning, network, language, etc).
 
+#### Anaconda ISO (installer) Modules
+
+The Anaconda installer can be configured by enabling or disabling its dbus modules.
+
+```toml
+[customizations.installer.modules]
+enable = [
+  "org.fedoraproject.Anaconda.Modules.Localization"
+]
+disable = [
+  "org.fedoraproject.Anaconda.Modules.Users"
+]
+```
+
+```json
+{
+  "customizations": {
+    "installer": {
+      "modules": {
+        "enable": [
+          "org.fedoraproject.Anaconda.Modules.Localization"
+        ],
+        "disable": [
+          "org.fedoraproject.Anaconda.Modules.Users"
+        ]
+      }
+    }
+  }
+}
+```
+
+The following module names are known and supported:
+- `org.fedoraproject.Anaconda.Modules.Localization`
+- `org.fedoraproject.Anaconda.Modules.Network`
+- `org.fedoraproject.Anaconda.Modules.Payloads`
+- `org.fedoraproject.Anaconda.Modules.Runtime`
+- `org.fedoraproject.Anaconda.Modules.Security`
+- `org.fedoraproject.Anaconda.Modules.Services`
+- `org.fedoraproject.Anaconda.Modules.Storage`
+- `org.fedoraproject.Anaconda.Modules.Subscription`
+- `org.fedoraproject.Anaconda.Modules.Timezone`
+- `org.fedoraproject.Anaconda.Modules.Users`
+
+*Note: The values are not validated. Any name listed under `enable` will be added to the Anaconda configuration. This way, new or unknown modules can be enabled. However, it also means that mistyped or incorrect values may cause Anaconda to fail to start.*
+
+By default, the following modules are enabled for all Anaconda ISOs:
+- `org.fedoraproject.Anaconda.Modules.Network`
+- `org.fedoraproject.Anaconda.Modules.Payloads`
+- `org.fedoraproject.Anaconda.Modules.Security`
+- `org.fedoraproject.Anaconda.Modules.Services`
+- `org.fedoraproject.Anaconda.Modules.Storage`
+- `org.fedoraproject.Anaconda.Modules.Users`
+
+
+##### Enable vs Disable priority
+
+The `disable` list is processed after the `enable` list and therefore takes priority. In other words, adding the same module in both `enable` and `disable` will result in the module being **disabled**.
+Furthermore, adding a module that is enabled by default to `disable` will result in the module being **disabled**.
+
+
 ## Building
 
 To build the container locally you can run

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -17,6 +17,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
@@ -257,9 +258,9 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	}
 	img.Kickstart.NetworkOnBoot = true
 	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules,
-		"org.fedoraproject.Anaconda.Modules.Users",
-		"org.fedoraproject.Anaconda.Modules.Services",
-		"org.fedoraproject.Anaconda.Modules.Security",
+		anaconda.ModuleUsers,
+		anaconda.ModuleServices,
+		anaconda.ModuleSecurity,
 	)
 
 	img.Kickstart.OSTree = &kickstart.OSTree{

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -257,6 +257,15 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 		img.Kickstart.KernelOptionsAppend = append(img.Kickstart.KernelOptionsAppend, kopts.Append)
 	}
 	img.Kickstart.NetworkOnBoot = true
+
+	instCust, err := customizations.GetInstaller()
+	if err != nil {
+		return nil, err
+	}
+	if instCust != nil && instCust.Modules != nil {
+		img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, instCust.Modules.Enable...)
+		img.DisabledAnacondaModules = append(img.DisabledAnacondaModules, instCust.Modules.Disable...)
+	}
 	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules,
 		anaconda.ModuleUsers,
 		anaconda.ModuleServices,


### PR DESCRIPTION
**bib: use anaconda package constants for module names**


---

**bib: enable customizing anaconda modules**

Connect the blueprint customization to the module configuration (enabled
and disabled) in the pipeline.

---

**README: document the new customizations.installer.modules options**

Based on the upstream blueprint documentation:
https://github.com/osbuild/osbuild.github.io/pull/100

---
