### PR TITLE
tekton: drop references to BASE_IMAGE_DIGESTS

### DIFF
--- a/.tekton/bootc-image-builder-pull-request.yaml
+++ b/.tekton/bootc-image-builder-pull-request.yaml
@@ -365,8 +365,6 @@ spec:
             workspace: workspace
       - name: deprecated-base-image-check
         params:
-          - name: BASE_IMAGES_DIGESTS
-            value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
           - name: IMAGE_URL
             value: $(tasks.build-container.results.IMAGE_URL)
           - name: IMAGE_DIGEST

--- a/.tekton/bootc-image-builder-push.yaml
+++ b/.tekton/bootc-image-builder-push.yaml
@@ -362,8 +362,6 @@ spec:
             workspace: workspace
       - name: deprecated-base-image-check
         params:
-          - name: BASE_IMAGES_DIGESTS
-            value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
           - name: IMAGE_URL
             value: $(tasks.build-container.results.IMAGE_URL)
           - name: IMAGE_DIGEST


### PR DESCRIPTION
PR #558 was merged without updating the configurations according to the migration notes, which broke the konflux pipelines.

See also
- https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.2/MIGRATION.md
- https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-remote/0.2/MIGRATION.md