### PR TITLE
docs: Authenticate to private repo using auth.json mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ The following volumes can be mounted inside the container:
 | `/output` | Used for storing the resulting artifacts               |    ✅     |
 | `/store`  | Used for the [osbuild store](https://www.osbuild.org/) |    No    |
 | `/rpmmd`  | Used for the DNF cache                                 |    No    |
+| `/auth.json`| Used with `-e REGISTRY_AUTH_FILE=/auth.json` to mount credentials for private repos|    No    |
 
 ## 📝 Build config
 


### PR DESCRIPTION
Not strictly a bootc-image-builder volume but I couldn't see in the docs how to use a private repo so came up with this approach and thought I'd capture it in case others need it.