### PR TITLE
bib/image: Fix Btrfs typo

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -175,7 +175,7 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 		}
 		rootFS.Type = c.RootFSType
 	} else if c.RootFSType == "btrfs" {
-		partitioningMode = disk.BtfrsPartitioningMode
+		partitioningMode = disk.BtrfsPartitioningMode
 	}
 
 	if err := applyFilesystemCustomizations(customizations, c); err != nil {


### PR DESCRIPTION
commit 627e2a added btrfs support to bib.
Fix a typo Btfrs -> Btrfs introduced with the commit.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>

Corresponding images PR: https://github.com/osbuild/images/pull/847