### PR TITLE
bib: make build the default subcommand

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,10 +16,9 @@ COPY ./group_osbuild-osbuild-fedora.repo /etc/yum.repos.d/
 COPY ./package-requires.txt .
 RUN grep -vE '^#' package-requires.txt | xargs dnf install -y && rm -f package-requires.txt && dnf clean all
 COPY --from=builder /build/bin/* /usr/bin/
-COPY entrypoint.sh /
 COPY bib/data /usr/share/bootc-image-builder
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/bootc-image-builder"]
 VOLUME /output
 WORKDIR /output
 VOLUME /store

--- a/README.md
+++ b/README.md
@@ -522,8 +522,7 @@ The contents of the file `$(pwd)/wheel-passwordless-sudo` should be
 
 Please report bugs to the [Bug Tracker](https://github.com/osbuild/bootc-image-builder/issues) and include instructions to reproduce and the output of:
 ```
-$ sudo podman run --rm -it --entrypoint=/usr/bin/bootc-image-builder \
-    quay.io/centos-bootc/bootc-image-builder:latest version
+$ sudo podman run --rm -it quay.io/centos-bootc/bootc-image-builder:latest version
 ```
 
 ## 📊 Project

--- a/devel/Containerfile
+++ b/devel/Containerfile
@@ -27,9 +27,8 @@ COPY --from=osbuild-builder /build/rpmbuild/RPMS/noarch/*.rpm /rpms/
 COPY ./package-requires.txt .
 RUN grep -vE '^#' package-requires.txt | xargs dnf install -y && rm -f package-requires.txt && dnf install -y /rpms/*.rpm && dnf clean all
 COPY --from=bib-builder /build/bin/bootc-image-builder /usr/bin/bootc-image-builder
-COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/bootc-image-builder"]
 VOLUME /output
 WORKDIR /output
 VOLUME /store

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-# TODO: This script only exists for legacy reasons, the plan is to start requiring
-# a e.g. `build-image` entrypoint.
-/usr/bin/bootc-image-builder build "$@"

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -33,7 +33,6 @@ def find_image_size_from(manifest_str):
 def test_manifest_smoke(build_container, tc):
     output = subprocess.check_output([
         *testutil.podman_run_common,
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         "manifest",
         *tc.bib_rootfs_args(),
@@ -53,7 +52,6 @@ def test_manifest_smoke(build_container, tc):
 def test_iso_manifest_smoke(build_container, tc):
     output = subprocess.check_output([
         *testutil.podman_run_common,
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         "manifest",
         "--type=anaconda-iso", f"{tc.container_ref}",
@@ -82,7 +80,6 @@ def test_manifest_disksize(tmp_path, build_container, tc):
         print(f"using {container_tag}")
         manifest_str = subprocess.check_output([
             *testutil.podman_run_common,
-            "--entrypoint", "/usr/bin/bootc-image-builder",
             build_container,
             "manifest", "--local",
             *tc.bib_rootfs_args(),
@@ -102,7 +99,6 @@ def test_manifest_local_checks_containers_storage_errors(build_container):
         "podman", "run", "--rm",
         "--privileged",
         "--security-opt", "label=type:unconfined_t",
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         "manifest", "--local", "arg-not-used",
     ], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf8")
@@ -121,7 +117,6 @@ def test_manifest_local_checks_containers_storage_works(tmp_path, build_containe
     with make_container(tmp_path) as container_tag:
         subprocess.run([
             *testutil.podman_run_common,
-            "--entrypoint=/usr/bin/bootc-image-builder",
             build_container,
             "manifest", "--local",
             *tc.bib_rootfs_args(),
@@ -141,7 +136,6 @@ def test_manifest_cross_arch_check(tmp_path, build_container):
         with pytest.raises(subprocess.CalledProcessError) as exc:
             subprocess.run([
                 *testutil.podman_run_common,
-                "--entrypoint=/usr/bin/bootc-image-builder",
                 build_container,
                 "manifest", "--target-arch=aarch64",
                 "--local", f"localhost/{container_tag}"
@@ -165,7 +159,6 @@ def test_manifest_rootfs_respected(build_container, tc):
     # TODO: derive container and fake "bootc install print-configuration"?
     output = subprocess.check_output([
         *testutil.podman_run_common,
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         "manifest", f"{tc.container_ref}",
     ])
@@ -183,7 +176,6 @@ def test_manifest_rootfs_override(build_container):
 
     output = subprocess.check_output([
         *testutil.podman_run_common,
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         "manifest", "--rootfs", "btrfs", f"{container_ref}",
     ])
@@ -216,7 +208,6 @@ def test_manifest_user_customizations_toml(tmp_path, build_container):
     output = subprocess.check_output([
         *testutil.podman_run_common,
         "-v", f"{config_toml_path}:/config.toml:ro",
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         "manifest", f"{container_ref}",
     ])
@@ -243,7 +234,6 @@ def test_manifest_installer_customizations(tmp_path, build_container):
     output = subprocess.check_output([
         *testutil.podman_run_common,
         "-v", f"{config_toml_path}:/config.toml:ro",
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         "manifest", "--type=anaconda-iso", f"{container_ref}",
     ])
@@ -297,7 +287,6 @@ def test_mount_ostree_error(tmpdir_factory, build_container):
         subprocess.check_output([
             *testutil.podman_run_common,
             "-v", f"{output_path}:/output",
-            "--entrypoint=/usr/bin/bootc-image-builder",
             build_container,
             "manifest", f"{container_ref}",
             "--config", "/output/config.json",
@@ -317,8 +306,9 @@ def test_manifest_checks_build_container_is_bootc(build_container, container_ref
     def check_image_ref():
         subprocess.check_output([
             *testutil.podman_run_common,
-            f'--entrypoint=["/usr/bin/bootc-image-builder", "manifest", "{container_ref}"]',
             build_container,
+            "manifest",
+            container_ref,
         ], stderr=subprocess.PIPE, encoding="utf8")
     if should_error:
         with pytest.raises(subprocess.CalledProcessError) as exc:
@@ -333,7 +323,6 @@ def test_manifest_target_arch_smoke(build_container, tc):
     # TODO: actually build an image too
     output = subprocess.check_output([
         *testutil.podman_run_common,
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         "manifest",
         *tc.bib_rootfs_args(),
@@ -386,7 +375,6 @@ def test_manifest_anaconda_module_customizations(tmpdir_factory, build_container
     output = subprocess.check_output([
         *testutil.podman_run_common,
         "-v", f"{output_path}:/output",
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
         "manifest",
         "--config", "/output/config.json",

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -122,7 +122,6 @@ def test_bib_help_hides_config(tmp_path, container_storage, build_fake_container
         "--security-opt", "label=type:unconfined_t",
         "-v", f"{container_storage}:/var/lib/containers/storage",
         "-v", f"{output_path}:/output",
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_fake_container,
         "manifest", "--help",
     ], check=True, capture_output=True, text=True)
@@ -159,7 +158,6 @@ def test_bib_version(tmp_path, container_storage, build_fake_container):
         "--security-opt", "label=type:unconfined_t",
         "-v", f"{container_storage}:/var/lib/containers/storage",
         "-v", f"{output_path}:/output",
-        "--entrypoint=/usr/bin/bootc-image-builder",
         build_fake_container,
         "version",
     ], check=True, capture_output=True, text=True)


### PR DESCRIPTION
Prior this commit, the bootc-image-builder container image had
a custom entrypoint that hardcoded the use of the build subcommand. This
meant that if a user wanted to use a different subcommand, they had to
overwrite the entrypoint.

This commit changes the cobra code in bib to fallback to build if no
subcommand was given. This is slighly ugly, but it allows us to remove
the custom entrypoint, streamlining the use of subcommands. Let's see
an example of calling the version subcommand:

Before:
podman run --rm -it --entrypoint=/usr/bin/bootc-image-builder \
    quay.io/centos-bootc/bootc-image-builder:latest version

After:
sudo podman run --rm -it \
    quay.io/centos-bootc/bootc-image-builder:latest version

Kudos to https://github.com/IKukhta for his code from
https://github.com/spf13/cobra/issues/823#issuecomment-870027246