### PR TITLE
bib: fix injecting default "build" arg into root for flags like --local

### DIFF
--- a/bib/cmd/bootc-image-builder/export_test.go
+++ b/bib/cmd/bootc-image-builder/export_test.go
@@ -9,6 +9,7 @@ var (
 	UpdateFilesystemSizes         = updateFilesystemSizes
 	GenPartitionTable             = genPartitionTable
 	CreateRand                    = createRand
+	BuildCobraCmdline             = buildCobraCmdline
 )
 
 func MockOsGetuid(new func() int) (restore func()) {


### PR DESCRIPTION
[draft as this needs tests]

In PR#608 we dropped the container entrypoint and moved the logic to detect what command to run into the cobra parsing.

However it seems certain situations like:
```
bootc-image-builder  --type qcow2 --tls-verify=true  --local quay.io/centos-bootc/centos-bootc:stream10
```
are not detected correctly (thanka to Chunfu Wen for reporting!).

This commit detect this usage and injects the build arg then too.

Closes https://github.com/osbuild/bootc-image-builder/issues/614