### PR TITLE
go.mod: drop 'toolchain go1.22.6'

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -2,8 +2,6 @@ module github.com/osbuild/bootc-image-builder/bib
 
 go 1.21.0
 
-toolchain go1.22.6
-
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/aws/aws-sdk-go v1.55.5


### PR DESCRIPTION
Downstream builds are failing with
```
2024-08-21 10:48:13,320 ERROR PackageManagerError: Required/recommended Go toolchain version '1.22.6' is not supported yet.
Error: PackageManagerError: Required/recommended Go toolchain version '1.22.6' is not supported yet.
  Please lower your required/recommended Go version and retry the request. You may also want to open a feature request on adding support for this version.
```

The toolchain line isn't a requirement in go.mod, so let's drop it.