### PR TITLE
bib: add new `--partition-mode` switch to enable lvm

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -63,6 +63,9 @@ type ManifestConfig struct {
 
 	// RootFSType specifies the filesystem type for the root partition
 	RootFSType string
+
+	// PartitionMode specifies the partiton mode to use (raw, lvm)
+	PartitionMode string
 }
 
 func Manifest(c *ManifestConfig) (*manifest.Manifest, error) {
@@ -216,6 +219,12 @@ func genPartitionTable(c *ManifestConfig, customizations *blueprint.Customizatio
 	if c.RootFSType == "btrfs" {
 		partitioningMode = disk.BtrfsPartitioningMode
 	}
+	// XXX: make this nicer, also figure out how this inteacts with
+	// btrfs partition mode
+	if c.PartitionMode == "lvm" {
+		partitioningMode = disk.LVMPartitioningMode
+	}
+
 	if err := checkFilesystemCustomizations(customizations.GetFilesystems(), partitioningMode); err != nil {
 		return nil, err
 	}

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -188,6 +188,7 @@ func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, *mTLSConfig, 
 	tlsVerify, _ := cmd.Flags().GetBool("tls-verify")
 	localStorage, _ := cmd.Flags().GetBool("local")
 	rootFs, _ := cmd.Flags().GetString("rootfs")
+	partMode, _ := cmd.Flags().GetString("partition-mode")
 
 	if targetArch != "" && arch.FromString(targetArch) != arch.Current() {
 		// TODO: detect if binfmt_misc for target arch is
@@ -306,6 +307,7 @@ func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, *mTLSConfig, 
 		DistroDefPaths:   distroDefPaths,
 		SourceInfo:       sourceinfo,
 		RootFSType:       rootfsType,
+		PartitionMode:    partMode,
 		DepsolverRootDir: container.Root(),
 	}
 
@@ -608,6 +610,7 @@ func buildCobraCmdline() (*cobra.Command, error) {
 	manifestCmd.Flags().StringArray("type", []string{"qcow2"}, fmt.Sprintf("image types to build [%s]", allImageTypesString()))
 	manifestCmd.Flags().Bool("local", false, "use a local container rather than a container from a registry")
 	manifestCmd.Flags().String("rootfs", "", "Root filesystem type. If not given, the default configured in the source container image is used.")
+	manifestCmd.Flags().String("partition-mode", "", "Partition mode. Supported: raw, lvm")
 	// --config is only useful for developers who run bib outside
 	// of a container to generate a manifest. so hide it by
 	// default from users.

--- a/package-requires.txt
+++ b/package-requires.txt
@@ -2,7 +2,7 @@
 # from the Containerfile by default, using leading '#' as comments.
 
 # This project uses osbuild
-osbuild osbuild-ostree osbuild-depsolve-dnf
+osbuild osbuild-ostree osbuild-depsolve-dnf osbuild-lvm2
 
 # We mount container images internally
 podman

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -359,6 +359,12 @@ def test_image_boots(image_type):
         # XXX: read the fully yaml instead?
         assert f"image: {image_type.container_ref}" in output
 
+        # XXX: put this into assert_fs_customizations or something
+        if image_type.partition_mode == "lvm":
+            exit_status, output = test_vm.run("findmnt", user="root", keyfile=image_type.ssh_keyfile_private_path)
+            assert exit_status == 0
+            assert "/dev/mapper/rootvg-rootlv" in output
+        
         # check the minsize specified in the build configuration for each mountpoint against the sizes in the image
         # TODO: replace 'df' call with 'parted --json' and find the partition size for each mountpoint
         exit_status, output = test_vm.run("df --output=target,size", user="root",

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -37,6 +37,7 @@ class ImageBuildResult(NamedTuple):
     img_arch: str
     container_ref: str
     rootfs: str
+    partition_mode: str
     username: str
     password: str
     ssh_keyfile_private_path: str
@@ -160,7 +161,8 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
             journal_output = journal_log_path.read_text(encoding="utf8")
             bib_output = bib_output_path.read_text(encoding="utf8")
             results.append(ImageBuildResult(
-                image_type, generated_img, tc.target_arch, tc.container_ref, tc.rootfs,
+                image_type, generated_img, tc.target_arch, tc.container_ref,
+                tc.rootfs, tc.partition_mode,
                 username, password, ssh_keyfile_private_path,
                 kargs, bib_output, journal_output))
 
@@ -262,6 +264,7 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
             *upload_args,
             *target_arch_args,
             *tc.bib_rootfs_args(),
+            *tc.bib_partition_mode_args(),
             "--local" if tc.local else "--local=false",
         ])
 
@@ -295,7 +298,8 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
     results = []
     for image_type in image_types:
         results.append(ImageBuildResult(
-            image_type, artifact[image_type], tc.target_arch, tc.container_ref, tc.rootfs,
+            image_type, artifact[image_type], tc.target_arch, tc.container_ref,
+            tc.rootfs, tc.partition_mode,
             username, password, ssh_keyfile_private_path,
             kargs, bib_output, journal_output, metadata))
     yield results

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -501,15 +501,15 @@ def find_bootc_install_to_fs_stage_from(manifest_str):
     raise ValueError(f"cannot find bootc.install-to-filesystem stage in manifest:\n{manifest_str}")
 
 
-def test_manifest_partition_mode_lvm(tmp_path, build_container):
+def test_manifest_partition_mode_lvm(build_container):
     container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
-    partMode = "lvm"
+    part_mode = "lvm"
 
     output = subprocess.check_output([
         *testutil.podman_run_common,
         "--entrypoint=/usr/bin/bootc-image-builder",
         build_container,
-        f"--partition-mode={partMode}",
+        f"--partition-mode={part_mode}",
         "manifest", f"{container_ref}",
     ])
     st = find_bootc_install_to_fs_stage_from(output)

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -23,10 +23,17 @@ class TestCase:
     # rootfs to use (e.g. ext4), some containers like fedora do not
     # have a default rootfs. If unset the container default is used.
     rootfs: str = ""
+    # partition-mode (e.g. lvm)
+    partition_mode: str = ""
 
     def bib_rootfs_args(self):
         if self.rootfs:
             return ["--rootfs", self.rootfs]
+        return []
+
+    def bib_partition_mode_args(self):
+        if self.partition_mode:
+            return ["--partition-mode", self.partition_mode]
         return []
 
     def __str__(self):
@@ -72,6 +79,9 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             for klass in (TestCaseCentos, TestCaseFedora)
             for img in ("raw", "qcow2")
         ]
+        # LVM
+        test_cases.append(
+            TestCaseCentos(image="raw", partition_mode="lvm"))
         # do a cross arch test too
         if platform.machine() == "x86_64":
             # TODO: re-enable once


### PR DESCRIPTION
This allows us to quickly enable lvm. Draft as I think we need to decide on the UX, i.e. if this should be done via the blueprint config or commandline or both and how it interacts with --rootfs and btrfs.

This needs:
~https://github.com/osbuild/images/pull/876~
~https://github.com/osbuild/osbuild/pull/1867~
~https://github.com/osbuild/osbuild/pull/1862~

but with that I was able to:
```
$ bootc-image-builder manifest --partition-mode lvm quay.io/centos-bootc/centos-bootc:stream9
...
$ kvm -m 1500 -cpu host disk.raw
...
localhost login: root
Password: 
[systemd]
Failed Units: 1
  bootc-generic-growpart.service
[root@localhost ~]# mount|grep "/sysroot "
/dev/mapper/rootvg-rootlv on /sysroot type xfs (ro,relatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota)
```
