### PR TITLE
test: add test for anaconda install on centos10

### DIFF
--- a/bib/data/defs/centos-10.yaml
+++ b/bib/data/defs/centos-10.yaml
@@ -27,6 +27,7 @@ anaconda-iso:
     - gdisk
     - glibc-all-langpacks
     - gnome-kiosk
+    - gnome-remote-desktop
     - google-noto-sans-cjk-ttc-fonts
     - grub2-tools
     - grub2-tools-extra
@@ -62,6 +63,7 @@ anaconda-iso:
     - nss-tools
     - openssh-clients
     - openssh-server
+    - openssl
     - ostree
     - pciutils
     - perl-interpreter

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -56,6 +56,13 @@ class TestCaseCentos(TestCase):
         "quay.io/centos-bootc/centos-bootc:stream9")
 
 
+@dataclasses.dataclass
+class TestCaseCentos10(TestCase):
+    container_ref: str = os.getenv(
+        "BIB_TEST_BOOTC_CONTAINER_TAG",
+        "quay.io/centos-bootc/centos-bootc:stream10")
+
+
 def gen_testcases(what):  # pylint: disable=too-many-return-statements
     if what == "manifest":
         return [TestCaseCentos(), TestCaseFedora()]
@@ -65,7 +72,9 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
     if what == "ami-boot":
         return [TestCaseCentos(image="ami"), TestCaseFedora(image="ami")]
     if what == "anaconda-iso":
-        return [TestCaseCentos(image="anaconda-iso"), TestCaseFedora(image="anaconda-iso")]
+        return [TestCaseCentos(image="anaconda-iso"),
+                TestCaseCentos10(image="anaconda-iso"),
+                TestCaseFedora(image="anaconda-iso")]
     if what == "qemu-boot":
         test_cases = [
             klass(image=img)


### PR DESCRIPTION
Small reproducer for https://github.com/osbuild/bootc-image-builder/issues/620

To test run:
```
$ sudo OSBUILD_TEST_QEMU_GUI=1 pytest -s -vv ./test/test_build.py::test_iso_installs[quay.io/centos-bootc/centos-bootc:stream10,anaconda-iso]
```

We probably do not want to merge as is (even if it woudl work) as it adds significant extra time to our tests :/