### PR TITLE
distrodefs: tweak dependencies for image installer

### DIFF
--- a/bib/data/defs/centos-10.yaml
+++ b/bib/data/defs/centos-10.yaml
@@ -4,7 +4,7 @@ anaconda-iso:
     - alsa-tools-firmware
     - anaconda
     - anaconda-dracut
-    - anaconda-install-env-deps
+    - anaconda-install-img-deps
     - anaconda-widgets
     - audit
     - bind-utils


### PR DESCRIPTION
Following the excellent work of Tomáš in [0] this commit updates the distro dependencies for centos10/rhel10 to include `anaconda-install-img-deps` which is what is required to get a working anaconda environment.

This with the new osbuild and the fix in [1] should fix https://github.com/osbuild/bootc-image-builder/issues/620

[0] https://github.com/osbuild/images/commit/54c2e63d76f6e9420f38b24b4022ccdfb64ce602#diff-8428a6822f263c812a988ac0a6548341cba28f9f4526fb6a5f6f53c2346f1b87R197
[1] https://github.com/osbuild/osbuild/pull/1846