### PR TITLE
bib: add a new `gce` image type (COMPOSER-2358)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The following image types are currently available via the `--type` argument:
 | `anaconda-iso`        | An unattended Anaconda installer that installs to the first disk found.               |
 | `raw`                 | Unformatted [raw disk](https://en.wikipedia.org/wiki/Rawdisk).                        |
 | `vhd`                 | [vhd](https://en.wikipedia.org/wiki/VHD_(file_format)) usable in Virtual PC, among others |
+| `gce`                 | [GCE](https://cloud.google.com/compute/docs/images#custom_images) |
 
 ## 💾 Target architecture
 

--- a/bib/internal/imagetypes/imagetypes.go
+++ b/bib/internal/imagetypes/imagetypes.go
@@ -18,6 +18,7 @@ var supportedImageTypes = map[string]imageType{
 	"raw":          imageType{Export: "image"},
 	"vmdk":         imageType{Export: "vmdk"},
 	"vhd":          imageType{Export: "vpc"},
+	"gce":          imageType{Export: "gce"},
 	"anaconda-iso": imageType{Export: "bootiso", ISO: true},
 	"iso":          imageType{Export: "bootiso", ISO: true},
 }

--- a/bib/internal/imagetypes/imagetypes_test.go
+++ b/bib/internal/imagetypes/imagetypes_test.go
@@ -63,15 +63,15 @@ func TestImageTypes(t *testing.T) {
 		},
 		"bad-image-type": {
 			imageTypes:  []string{"bad"},
-			expectedErr: errors.New(`unsupported image type "bad", valid types are ami, anaconda-iso, iso, qcow2, raw, vhd, vmdk`),
+			expectedErr: errors.New(`unsupported image type "bad", valid types are ami, anaconda-iso, gce, iso, qcow2, raw, vhd, vmdk`),
 		},
 		"bad-in-good": {
 			imageTypes:  []string{"ami", "raw", "vmdk", "qcow2", "something-else-what-is-this"},
-			expectedErr: errors.New(`unsupported image type "something-else-what-is-this", valid types are ami, anaconda-iso, iso, qcow2, raw, vhd, vmdk`),
+			expectedErr: errors.New(`unsupported image type "something-else-what-is-this", valid types are ami, anaconda-iso, gce, iso, qcow2, raw, vhd, vmdk`),
 		},
 		"all-bad": {
 			imageTypes:  []string{"bad1", "bad2", "bad3", "bad4", "bad5", "bad42"},
-			expectedErr: errors.New(`unsupported image type "bad1", valid types are ami, anaconda-iso, iso, qcow2, raw, vhd, vmdk`),
+			expectedErr: errors.New(`unsupported image type "bad1", valid types are ami, anaconda-iso, gce, iso, qcow2, raw, vhd, vmdk`),
 		},
 	}
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -135,6 +135,7 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload):
         "raw": pathlib.Path(output_path) / "image/disk.raw",
         "vmdk": pathlib.Path(output_path) / "vmdk/disk.vmdk",
         "vhd": pathlib.Path(output_path) / "vpc/disk.vhd",
+        "gce": pathlib.Path(output_path) / "gce/image.tgz",
         "anaconda-iso": pathlib.Path(output_path) / "bootiso/install.iso",
     }
     assert len(artifact) == len(set(tc.image for tc in gen_testcases("all"))), \
@@ -454,7 +455,7 @@ def test_iso_installs(image_type):
 @pytest.mark.parametrize("images", gen_testcases("multidisk"), indirect=["images"])
 def test_multi_build_request(images):
     artifacts = set()
-    expected = {"disk.qcow2", "disk.raw", "disk.vhd", "disk.vmdk"}
+    expected = {"disk.qcow2", "disk.raw", "disk.vhd", "disk.vmdk", "image.tgz"}
     for result in images:
         filename = os.path.basename(result.img_path)
         assert result.img_path.exists()

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -4,7 +4,7 @@ import os
 import platform
 
 # disk image types can be build from a single manifest
-DISK_IMAGE_TYPES = ["qcow2", "raw", "vmdk", "vhd"]
+DISK_IMAGE_TYPES = ["qcow2", "raw", "vmdk", "vhd", "gce"]
 
 # supported images that can be booted in a cloud
 CLOUD_BOOT_IMAGE_TYPES = ["ami"]


### PR DESCRIPTION
This commit adds a new image type `raw-tgz` that contains a tar
file with the raw image inside. This was requested by GCP.

See also https://github.com/osbuild/images/pull/923
This will need https://github.com/osbuild/osbuild/pull/1886 first.