### PR TITLE
bib: add final newline after `bib manifest`

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -328,7 +328,7 @@ func cmdManifest(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("cannot generate manifest: %w", err)
 	}
-	fmt.Print(string(mf))
+	fmt.Println(string(mf))
 	return nil
 }
 


### PR DESCRIPTION
This is a trivial commit that adds a final newline to `bootc-image-builder manifest`.