### PR TITLE
buildconfig: disable tests for undecoded keys for now

### DIFF
--- a/bib/internal/buildconfig/config.go
+++ b/bib/internal/buildconfig/config.go
@@ -59,13 +59,9 @@ func decodeTomlBuildConfig(r io.Reader, what string) (*BuildConfig, error) {
 	dec := toml.NewDecoder(r)
 
 	var conf BuildConfig
-	metadata, err := dec.Decode(&conf)
+	_, err := dec.Decode(&conf)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode %q: %w", what, err)
-	}
-
-	if len(metadata.Undecoded()) > 0 {
-		return nil, fmt.Errorf("cannot decode %q: unknown keys found: %v", what, metadata.Undecoded())
 	}
 
 	return &conf, nil

--- a/bib/internal/buildconfig/config_test.go
+++ b/bib/internal/buildconfig/config_test.go
@@ -157,3 +157,24 @@ func TestJsonUnknownKeysError(t *testing.T) {
 
 	assert.ErrorContains(t, err, `json: unknown field "birds"`)
 }
+
+func TestReadConfigIsssue655(t *testing.T) {
+	fakeUserCnfPath := makeFakeConfig(t, "config.toml", `
+[[customizations.filesystem]]
+mountpoint = "/"
+minsize = 1000
+`)
+
+	conf, err := buildconfig.ReadWithFallback(fakeUserCnfPath)
+	assert.NoError(t, err)
+	assert.Equal(t, &buildconfig.BuildConfig{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					Mountpoint: "/",
+					MinSize:    1000,
+				},
+			},
+		},
+	}, conf)
+}

--- a/bib/internal/buildconfig/config_test.go
+++ b/bib/internal/buildconfig/config_test.go
@@ -133,16 +133,6 @@ func TestReadLegacyJSONConfig(t *testing.T) {
 	assert.Equal(t, expectedBuildConfig, cfg)
 }
 
-func TestTomlUnknownKeysError(t *testing.T) {
-	fakeUserCnfPath := makeFakeConfig(t, "config.toml", `
-[[birds]]
-name = "toucan"
-`)
-	_, err := buildconfig.ReadWithFallback(fakeUserCnfPath)
-
-	assert.ErrorContains(t, err, "unknown keys found: [birds birds.name]")
-}
-
 func TestJsonUnknownKeysError(t *testing.T) {
 	fakeUserCnfPath := makeFakeConfig(t, "config.json", `
 {

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -435,7 +435,7 @@ def test_manifest_fs_customizations_smoke_toml(tmp_path, build_container):
     rootfs = "xfs"
 
     expected_fs_customizations = {
-        "/":  10 * 1024 * 1024 * 1024,
+        "/": 10 * 1024 * 1024 * 1024,
         "/var/data": 20 * 1024 * 1024 * 1024,
     }
 


### PR DESCRIPTION
This commit partially reverts PT#549 to unblock filesystem
customizations in bib.

This is a short term fix and we should revert and do something
smarter like https://github.com/osbuild/images/pull/951 or see
if we can do better in the toml unmarshaling. But to unblock
toml customizations this is a (IMHO) reasonable first step.

Closes: https://github.com/osbuild/bootc-image-builder/issues/655