### PR TITLE
container: run `dnf check` in container for dnf4/dnf5 compat

### DIFF
--- a/bib/internal/container/container.go
+++ b/bib/internal/container/container.go
@@ -123,13 +123,20 @@ func (c *Container) ExecArgv() []string {
 	return []string{"podman", "exec", "-i", c.id}
 }
 
-// InitDNF initializes dnf in the container. This is necessary when the caller wants to read the image's dnf
-// repositories, but they are not static, but rather configured by dnf dynamically. The primaru use-case for
-// this is RHEL and subscription-manager.
+// InitDNF initializes dnf in the container. This is necessary when
+// the caller wants to read the image's dnf repositories, but they are
+// not static, but rather configured by dnf dynamically. The primaru
+// use-case for this is RHEL and subscription-manager.
 //
-// The implementation is simple: We just run plain `dnf` in the container.
+// The implementation is simple: We just run plain `dnf` in the
+// container so that the subscription-manager gets initialized. For
+// compatibility with both dnf and dnf5 we cannot just run "dnf" as
+// dnf5 will error and do nothing in this case. So we use "dnf check
+// --duplicates" as this is fast on both dnf4/dnf5 (just doing "dnf5
+// check" without arguments takes around 25s so that is not a great
+// option).
 func (c *Container) InitDNF() error {
-	if output, err := exec.Command("podman", "exec", c.id, "dnf").CombinedOutput(); err != nil {
+	if output, err := exec.Command("podman", "exec", c.id, "dnf", "check", "--duplicates").CombinedOutput(); err != nil {
 		return fmt.Errorf("initializing dnf in %s container failed: %w\noutput:\n%s", c.id, err, string(output))
 	}
 

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -44,8 +44,8 @@ class TestCaseFedora(TestCase):
 
 
 @dataclasses.dataclass
-class TestCaseFedora41(TestCase):
-    container_ref: str = "quay.io/fedora/fedora-bootc:41"
+class TestCaseFedora42(TestCase):
+    container_ref: str = "quay.io/fedora/fedora-bootc:42"
     rootfs: str = "btrfs"
 
 
@@ -103,7 +103,7 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
         return [
             TestCaseCentos(target_arch="arm64"),
             # TODO: merge with TestCaseFedora once the arches are build there
-            TestCaseFedora41(target_arch="ppc64le"),
-            TestCaseFedora41(target_arch="s390x"),
+            TestCaseFedora42(target_arch="ppc64le"),
+            TestCaseFedora42(target_arch="s390x"),
         ]
     raise ValueError(f"unknown test-case type {what}")


### PR DESCRIPTION
This is an alternative idea to PR#651 - we run `dnf` inside the
container to init the dnf system. However with `dnf5` this no
longer works and it just throws an error.

So instead we run `dnf check` which should work on both dnf{4,5}.

---

test: move `target-arch-smoke` testcases to Fedora42 (for
 dnf5)

This will give us testing for dnf5 as well.


[draft until tests are good and I double checked dnf sources]