### PR TITLE
Use a libosinfo compatible label format for the Anaconda ISO

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install test dependencies
       run: |
         sudo apt update
-        sudo apt install -y podman python3-pytest python3-paramiko python3-boto3 flake8 qemu-system-x86 qemu-efi-aarch64 qemu-system-arm qemu-user-static pylint
+        sudo apt install -y podman python3-pytest python3-paramiko python3-boto3 flake8 qemu-system-x86 qemu-efi-aarch64 qemu-system-arm qemu-user-static pylint libosinfo-bin
     - name: Diskspace (before)
       run: |
         df -h

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -21,6 +21,7 @@ prepare:
     - qemu-kvm
     - qemu-system-aarch64
     - qemu-user-static
+    - libosinfo
 execute:
   how: tmt
   script: |

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -41,12 +41,14 @@ class TestCase:
 class TestCaseFedora(TestCase):
     container_ref: str = "quay.io/fedora/fedora-bootc:40"
     rootfs: str = "btrfs"
+    osinfo_template: str = "Fedora Server 40 ({arch})"
 
 
 @dataclasses.dataclass
 class TestCaseFedora42(TestCase):
     container_ref: str = "quay.io/fedora/fedora-bootc:42"
     rootfs: str = "btrfs"
+    osinfo_template: str = "Fedora Server 42 ({arch})"
 
 
 @dataclasses.dataclass
@@ -54,6 +56,7 @@ class TestCaseCentos(TestCase):
     container_ref: str = os.getenv(
         "BIB_TEST_BOOTC_CONTAINER_TAG",
         "quay.io/centos-bootc/centos-bootc:stream9")
+    osinfo_template: str = "CentOS Stream 9 ({arch})"
 
 
 def gen_testcases(what):  # pylint: disable=too-many-return-statements


### PR DESCRIPTION
Label the anaconda ISO depending on the container OS
and make the ISO label format compatible with libosinfo.

This will make any software using libosinfo to be able
to correctly detect the OS contained in the ISO and
where to find the initrd and the kernel.

Resolves: https://github.com/osbuild/bootc-image-builder/issues/265