### PR TITLE
container: copy RHSM secrets into the ephemeral container

### DIFF
--- a/bib/internal/container/export_test.go
+++ b/bib/internal/container/export_test.go
@@ -1,0 +1,9 @@
+package container
+
+func MockSecretDirSrc(new string) (restore func()) {
+	saved := secretDirSrc
+	secretDirSrc = new
+	return func() {
+		secretDirSrc = saved
+	}
+}


### PR DESCRIPTION
We recently ran into a regression in bib where it can no longer access subscribed content. This is caused by commit cfe9c68. This commit changed the way osbuild-dnf-json was run, instead of inside the container it runs now outside with the dnfjson.SetRootDir() mount of the container. But this means that the secrets mapped via a volume from `-v /run/secrets:/run/secrets` are no longer accessible because this dir is only available inside the mount namespace of the container but not available from the outside.

Instead of the mount this commit uses a rather blunt approach and just copies the content of /run/secrets into the container. This is (very) ugly but it unbreaks the functionality.

[edit: this seems to be not sufficient, subscribed content is still not found but the client error error is gone, dnfjson just does not find packages anymore]