### PR TITLE
bib: run "dnf" inside the container again

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -60,8 +60,8 @@ type ManifestConfig struct {
 	// Extracted information about the source container image
 	SourceInfo *source.Info
 
-	// Path to the tree that contains /etc used for osbuild-depsolve-dnf
-	DepsolverRootDir string
+	// Command to run the depsolver
+	DepsolverCmd []string
 
 	// RootFSType specifies the filesystem type for the root partition
 	RootFSType string


### PR DESCRIPTION
In 17d3b56 osbuild-dnf-json was changed to run outside the container. This lead to a regression in accessing subscribed content. This commit partially reverts this commit to run dnf again inside the container so that we have access to the /run/secrets and RHEL repos.

[a different approach over pr#668, this one works in the (not yet public) test-case we have]