### PR TITLE
buildconfig: support passing build config via `stdin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,9 @@ sudo podman run \
     quay.io/centos-bootc/centos-bootc:stream9
 ```
 
+The configuration can also be passed in via stdin when `--config -`
+is used. Only JSON configuration is supported in this mode.
+
 ### Users (`user`, array)
 
 Possible fields:

--- a/bib/internal/buildconfig/config_test.go
+++ b/bib/internal/buildconfig/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/images/pkg/blueprint"
 
@@ -167,4 +168,18 @@ minsize = 1000
 			},
 		},
 	}, conf)
+}
+
+func TestReadWithFallbackFromStdin(t *testing.T) {
+	fakeUserCnfPath := makeFakeConfig(t, "fake-stdin", fakeConfigJSON)
+	fakeStdinFp, err := os.Open(fakeUserCnfPath)
+	require.NoError(t, err)
+	defer fakeStdinFp.Close()
+
+	restore := buildconfig.MockOsStdin(fakeStdinFp)
+	defer restore()
+
+	cfg, err := buildconfig.ReadWithFallback("-")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBuildConfig, cfg)
 }

--- a/bib/internal/buildconfig/export_test.go
+++ b/bib/internal/buildconfig/export_test.go
@@ -1,9 +1,21 @@
 package buildconfig
 
+import (
+	"os"
+)
+
 func MockConfigRootDir(newDir string) (restore func()) {
 	saved := configRootDir
 	configRootDir = newDir
 	return func() {
 		configRootDir = saved
+	}
+}
+
+func MockOsStdin(new *os.File) (restore func()) {
+	saved := osStdin
+	osStdin = new
+	return func() {
+		osStdin = saved
 	}
 }


### PR DESCRIPTION
This commit adds support for reading the build config via stdin. To do that the `-config` switch now supports `-` and with that it will use `os.Stdin` insteadof readin the file. Because we have no file extension to auto-detect the format only JSON is supported in this mode.

This feature will be used by osbuild-composer when it adds bootc image mode integration.