### PR TITLE
fix: use remove-signatures in skopeo copy stages

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -360,6 +360,7 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	// The ref is not needed and will be removed from the ctor later
 	// in time
 	img := image.NewAnacondaContainerInstaller(containerSource, "")
+	img.ContainerRemoveSignatures = true
 	img.SquashfsCompression = "zstd"
 
 	img.Product = c.SourceInfo.OSRelease.Name


### PR DESCRIPTION
According to [1] neither Docker daemon nor OCI support storing
the container signatures, and skopeo copy refuses to just silently drop
them and fails.

When using `skopeo copy --remove-signatures` to make the copy, the
signatures will be still read and policy.json will still be enforced,
they just won’t be written into the destination.

[1] https://github.com/containers/skopeo/issues/589#issuecomment-453894401