### PR TITLE
test: fix the testcase strings to not include `osinfo_template`

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -41,14 +41,12 @@ class TestCase:
 class TestCaseFedora(TestCase):
     container_ref: str = "quay.io/fedora/fedora-bootc:40"
     rootfs: str = "btrfs"
-    osinfo_template: str = "Fedora Server 40 ({arch})"
 
 
 @dataclasses.dataclass
 class TestCaseFedora42(TestCase):
     container_ref: str = "quay.io/fedora/fedora-bootc:42"
     rootfs: str = "btrfs"
-    osinfo_template: str = "Fedora Server 42 ({arch})"
 
 
 @dataclasses.dataclass
@@ -56,7 +54,16 @@ class TestCaseCentos(TestCase):
     container_ref: str = os.getenv(
         "BIB_TEST_BOOTC_CONTAINER_TAG",
         "quay.io/centos-bootc/centos-bootc:stream9")
-    osinfo_template: str = "CentOS Stream 9 ({arch})"
+
+
+def test_testcase_nameing():
+    """
+    Ensure the testcase naming does not change without us knowing as those
+    are visible when running "pytest --collect-only"
+    """
+    tc = TestCaseFedora()
+    expected = "quay.io/fedora/fedora-bootc:40,btrfs"
+    assert f"{tc}" == expected, f"{tc} != {expected}"
 
 
 def gen_testcases(what):  # pylint: disable=too-many-return-statements


### PR DESCRIPTION
This commit fixes the testcase string representation to not include the `osinfo_template` string and adds a test case to not accidentally regress here. Currently our test case strings look like:
```
<Dir bootc-image-builder>
  <Dir test>
    <Module test_build.py>
      <Function test_container_builds>
      <Function test_image_is_generated[quay.io/centos-bootc/centos-bootc:stream9,qcow2+raw+vmdk+vhd+gce,CentOS Stream 9 ({arch})]>
      <Function test_image_boots[quay.io/centos-bootc/centos-bootc:stream9,raw,CentOS Stream 9 ({arch})]>
...
```
which is an accident (not the {arch} part in the output above). A testcase should ideally only contain what

Instead of putting the osinfo_template into the testcase itself, have a function that generates it. It has downsides (now the osinfo_template is more disconnected from the testcase) so we could move it also back into testcase or we could exclude osinfo_template from the string generation. Ideas welcome here, my current approach feels okay but not like it's perfect yet.