### PR TITLE
test: add anaconda-iso build tests with signed containers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,7 @@ jobs:
         echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel-kubic-libcontainers-unstable.list
         curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
         sudo apt update
-        sudo apt install -y podman
+        sudo apt install -y podman skopeo
     - name: Install python test deps
       run: |
         # make sure test deps are available for root

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -23,6 +23,8 @@ class TestCase:
     # rootfs to use (e.g. ext4), some containers like fedora do not
     # have a default rootfs. If unset the container default is used.
     rootfs: str = ""
+    # Sign the container_ref and use the new signed image instead of the original one
+    sign: bool = False
 
     def bib_rootfs_args(self):
         if self.rootfs:
@@ -31,7 +33,7 @@ class TestCase:
 
     def __str__(self):
         return ",".join([
-            attr
+            f"{name}={attr}"
             for name, attr in inspect.getmembers(self)
             if not name.startswith("_") and not callable(attr) and attr
         ])
@@ -68,7 +70,11 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
     if what == "ami-boot":
         return [TestCaseCentos(image="ami"), TestCaseFedora(image="ami")]
     if what == "anaconda-iso":
-        return [TestCaseCentos(image="anaconda-iso"), TestCaseFedora(image="anaconda-iso")]
+        return [
+            TestCaseFedora(image="anaconda-iso", sign=True),
+            TestCaseCentos(image="anaconda-iso"),
+            TestCaseFedora(image="anaconda-iso"),
+        ]
     if what == "qemu-boot":
         test_cases = [
             klass(image=img)

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -147,3 +147,13 @@ podman_run_common = [
     "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
     "--security-opt", "label=type:unconfined_t",
 ]
+
+
+def get_ip_from_default_route():
+    default_route = subprocess.run([
+        "ip",
+        "route",
+        "list",
+        "default"
+    ], check=True, capture_output=True, text=True).stdout
+    return default_route.split()[8]


### PR DESCRIPTION
Add anaconda-iso iso build tests with signed containers.
The rest of the images can be also added to the test once
[1] and [2] are merged

[1] https://github.com/osbuild/images/pull/990
[2] https://github.com/osbuild/osbuild/pull/1906

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
