### PR TITLE
bib: remove usage of `BootcLegacyDiskImage` (for qemu-9.1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install test dependencies
       run: |
         sudo apt update
-        sudo apt install -y python3-pytest python3-paramiko python3-boto3 flake8 qemu-system-x86 qemu-efi-aarch64 qemu-system-arm qemu-user-static pylint libosinfo-bin
+        sudo apt install -y python3-pytest python3-paramiko python3-boto3 flake8 pylint libosinfo-bin
     - name: Diskspace (before)
       run: |
         df -h
@@ -90,6 +90,18 @@ jobs:
         sudo rm -rf /var/lib/containers/storage
         sudo mkdir -p /etc/containers
         echo -e "[storage]\ndriver = \"overlay\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"" | sudo tee /etc/containers/storage.conf
+    - name: Updating qemu-user
+      run: |
+        # get qemu-9 with openat2 patches via qemu-user-static, that
+        # has no dependencies so just install.
+        # XXX: remove once ubuntu ships qemu-9.1
+        sudo apt install -y software-properties-common
+        sudo apt-add-repository -y ppa:mvo/qemu
+        sudo apt install --no-install-recommends -y qemu-user-static
+        # Now remove ppa again, the metadata confuses apt. Then install
+        # qemu-system-* from the regular repo again.
+        sudo apt-add-repository --remove -y ppa:mvo/qemu
+        sudo apt install -y qemu-system-arm qemu-system-x86 qemu-efi-aarch64
     - name: Install python test deps
       run: |
         # make sure test deps are available for root

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -388,19 +388,11 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 	mf.Distro = manifest.DISTRO_FEDORA
 	runner := &runner.Linux{}
 
-	// Remove the "NewBootcLegacyDiskImage" if part below and
-	// *only* use the "else" part of the code once either of the
-	// following is available in centos/rhel
-	// https://github.com/containers/bootc/pull/462
-	// https://www.mail-archive.com/qemu-devel@nongnu.org/msg1034508.html
-	if c.Architecture != arch.Current() {
-		legacyImg := image.NewBootcLegacyDiskImage(img)
-		err = legacyImg.InstantiateManifestFromContainers(&mf, []container.SourceSpec{containerSource}, runner, rng)
-	} else {
-		err = img.InstantiateManifestFromContainers(&mf, []container.SourceSpec{containerSource}, runner, rng)
+	if err := img.InstantiateManifestFromContainers(&mf, []container.SourceSpec{containerSource}, runner, rng); err != nil {
+		return nil, err
 	}
 
-	return &mf, err
+	return &mf, nil
 }
 
 func labelForISO(os *source.OSRelease, arch *arch.Arch) string {

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -104,12 +104,8 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
         ]
         # do a cross arch test too
         if platform.machine() == "x86_64":
-            # TODO: re-enable once
-            # https://github.com/osbuild/bootc-image-builder/issues/619
-            # is resolved
-            # test_cases.append(
-            #    TestCaseC9S(image="raw", target_arch="arm64"))
-            pass
+            test_cases.append(
+                TestCaseC9S(image="raw", target_arch="arm64"))
         elif platform.machine() == "arm64":
             # TODO: add arm64->x86_64 cross build test too
             pass


### PR DESCRIPTION
This commit enables bib to work with the qemu-9.1+openat2 patches as proposed in https://src.fedoraproject.org/rpms/qemu/pull-request/69.

With the qemu-user-statuc-aarch64 rpm produced by `fedpkg mockbuild` from this package the cross-arch test build works again.
```
$ sudo PYTHONPATH=. pytest './test/test_build.py::test_image_boots[quay.io/centos-bootc/centos-bootc:stream9,raw,CentOS Stream 9 ({arch}),arm64]' -s -vv
============================= test session starts ==============================
platform linux -- Python 3.12.7, pytest-7.4.3, pluggy-1.3.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/mvogt/devel/osbuild/bootc-image-builder
configfile: pytest.ini
plugins: repeat-0.9.3, xdist-3.5.0
collected 1 item

test/test_build.py::test_image_boots[quay.io/centos-bootc/centos-bootc:stream9,raw,CentOS Stream 9 ({arch}),arm64] [1/2] STEP 1/9: FROM registry.fedoraproject.org/fedora:40 AS builder
...
PASSEDChecking disk usage for /var/tmp/bib-tests/shared0/68b20145da2cd3f2/image/disk.raw
NOTE: disk usage after /var/tmp/bib-tests/shared0/68b20145da2cd3f2/image/disk.raw: 712472.71936 / 1998694.907904
Untagged: quay.io/centos-bootc/centos-bootc:stream9
Deleted: 0de1f90b11cbe7e2768101f6c55b4dd9841c13a2f87c8d9c177aea74ade88050

============================= slowest 10 durations =============================
1033.54s setup    test/test_build.py::test_image_boots[quay.io/centos-bootc/centos-bootc:stream9,raw,CentOS Stream 9 ({arch}),arm64]
67.62s call     test/test_build.py::test_image_boots[quay.io/centos-bootc/centos-bootc:stream9,raw,CentOS Stream 9 ({arch}),arm64]
2.30s teardown test/test_build.py::test_image_boots[quay.io/centos-bootc/centos-bootc:stream9,raw,CentOS Stream 9 ({arch}),arm64]
======================== 1 passed in 1103.58s (0:18:23) ========================
```

---

This will also re-enable the cross-arch test via an updated qemu-user-static (same patches for the GH runners as we use for the f41 rpm packages of qemu)