### PR TITLE
image: add platform support for s390x, ppc64le in the ISO

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -428,6 +428,22 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 			},
 			UEFIVendor: c.SourceInfo.UEFIVendor,
 		}
+	case arch.ARCH_S390X:
+		img.Platform = &platform.S390X{
+			Zipl: true,
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_ISO,
+			},
+		}
+	case arch.ARCH_PPC64LE:
+		img.Platform = &platform.PPC64LE{
+			BIOS: true,
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_ISO,
+			},
+		}
+	default:
+		return nil, fmt.Errorf("unsupported architecture %v", c.Architecture)
 	}
 
 	img.Filename = "install.iso"


### PR DESCRIPTION
[draft as this assumes an ISO actually makes sense for s390x/ppc64le]

This commit populates the "img.Platform" struct when building for s390x and ppc64le.

No tests right now sadly, this should be looked into but given that it is known broken right now this change can hardly make it worse.

Closes: https://github.com/osbuild/bootc-image-builder/issues/686