### PR TITLE
bib: extract common `platformFor()` helper and add tests

### DIFF
--- a/bib/cmd/bootc-image-builder/export_test.go
+++ b/bib/cmd/bootc-image-builder/export_test.go
@@ -10,6 +10,7 @@ var (
 	GenPartitionTable             = genPartitionTable
 	CreateRand                    = createRand
 	BuildCobraCmdline             = buildCobraCmdline
+	PlatformFor                   = platformFor
 )
 
 func MockOsGetuid(new func() int) (restore func()) {

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -428,6 +428,22 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 			},
 			UEFIVendor: c.SourceInfo.UEFIVendor,
 		}
+	case arch.ARCH_S390X:
+		img.Platform = &platform.S390X{
+			Zipl: true,
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_ISO,
+			},
+		}
+	case arch.ARCH_PPC64LE:
+		img.Platform = &platform.PPC64LE{
+			BIOS: true,
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_ISO,
+			},
+		}
+	default:
+		return nil, fmt.Errorf("unsupported architecture %v", archi)
 	}
 
 	img.Filename = "install.iso"


### PR DESCRIPTION
[build on top of https://github.com/osbuild/bootc-image-builder/pull/692]

This commit extracts a common `platformFor` helper to generate
a platform for the (arch, imageForamat, UEFIVendor) tuple.

Note that this also change is not a pure refactor but change
the following behavior:

- `QCOW2Compat: "1.1"` is no longer set because this is the
  default in qemu since 2013 (upstream commit 8ad1898c
  version qemu 1.7)
- uefi vendor is now set for the disk image according to source
  info. This used to be hardcoded for aarch64 and unset for the
  others. This should be mostly irrelevant as only installers
  and the bootc legacy pipeline that uses ostree stages directly
  need it. But having it should do not harm and until PR#689
  is merged we will need for the bootc legacy pipeline.

But if this looks too risky I can just close the PR, adding architectures
happens rarely enough and maybe this refactor is overkill.
