### PR TITLE
workflow: fix plan filter for `testingfarm{,-unit}` action

### DIFF
--- a/.github/workflows/testingfarm-unit.yml
+++ b/.github/workflows/testingfarm-unit.yml
@@ -34,7 +34,7 @@ jobs:
       uses: sclorg/testing-farm-as-github-action@v3
       with:
         compose: Fedora-40
-        tmt_plan_filter: "unit-go.fmf"
+        tmt_plan_regex: "/plans/unit-go"
         api_key: ${{ secrets.TF_API_KEY }}
         git_url: ${{ github.event.pull_request.head.repo.clone_url }}
         git_ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/testingfarm.yml
+++ b/.github/workflows/testingfarm.yml
@@ -51,7 +51,7 @@ jobs:
       uses: sclorg/testing-farm-as-github-action@v3
       with:
         compose: Fedora-40
-        tmt_plan_filter: "integration.fmf"
+        tmt_plan_regex: "/plans/integration"
         api_key: ${{ secrets.TF_API_KEY }}
         git_url: ${{ github.event.pull_request.head.repo.clone_url }}
         git_ref: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
The testingfarm-unit testplan is wrong, this is why the action is failing. Sadly because of the way it runs (via the `on: pull_request_target`) only what is in `main` will be run so it is hard to test these actions before merging :(