### PR TITLE
fix: add a missing dependency for the anaconda-iso installer

### DIFF
--- a/bib/data/defs/fedora-40.yaml
+++ b/bib/data/defs/fedora-40.yaml
@@ -75,6 +75,7 @@ anaconda-iso:
     - perl-interpreter
     - pigz
     - plymouth
+    - python3-pam
     - python3-pyatspi
     - rdma-core
     - realtek-firmware


### PR DESCRIPTION
Add the the python3-pam package to the list of dependencies
as it seems to be required for the anaconda-core rpm.

Resolves: fedora-iot/iot-distro#66

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
