### PR TITLE
fix: install anaconda-install-img-deps package in anaconda installers.

### DIFF
--- a/bib/data/defs/fedora-40.yaml
+++ b/bib/data/defs/fedora-40.yaml
@@ -6,7 +6,7 @@ anaconda-iso:
     - alsa-tools-firmware
     - anaconda
     - anaconda-dracut
-    - anaconda-install-env-deps
+    - anaconda-install-img-deps
     - anaconda-widgets
     - atheros-firmware
     - audit
@@ -75,7 +75,6 @@ anaconda-iso:
     - perl-interpreter
     - pigz
     - plymouth
-    - python3-pam
     - python3-pyatspi
     - rdma-core
     - realtek-firmware


### PR DESCRIPTION
According to the anaconda team we should be using the `anaconda-install-img-deps`
metapackage to install all the boot.iso image dependencies.

Relates: #707
Relates: fedora-iot/iot-distro#66


Signed-off-by: Miguel Martín <mmartinv@redhat.com>
