### PR TITLE
workflow: move workflow to run on ubuntu-24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
   integration:
     # TODO: run this also via tmt/testing-farm
     name: "Integration"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -79,21 +79,17 @@ jobs:
     - name: Install test dependencies
       run: |
         sudo apt update
-        sudo apt install -y podman python3-pytest python3-paramiko python3-boto3 flake8 qemu-system-x86 qemu-efi-aarch64 qemu-system-arm qemu-user-static pylint libosinfo-bin
+        sudo apt install -y python3-pytest python3-paramiko python3-boto3 flake8 qemu-system-x86 qemu-efi-aarch64 qemu-system-arm qemu-user-static pylint libosinfo-bin
     - name: Diskspace (before)
       run: |
         df -h
         sudo du -sh * /var/tmp /tmp /var/lib/containers | sort -sh
-    - name: Update podman
-      run:  |
-        # from https://askubuntu.com/questions/1414446/whats-the-recommended-way-of-installing-podman-4-in-ubuntu-22-04
-        ubuntu_version='22.04'
-        key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key"
-        sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}"
-        echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel-kubic-libcontainers-unstable.list
-        curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
-        sudo apt update
-        sudo apt install -y podman skopeo
+    - name: Workaround podman issues in GH actions
+      run: |
+        # see https://github.com/osbuild/bootc-image-builder/issues/446
+        sudo rm -rf /var/lib/containers/storage
+        sudo mkdir -p /etc/containers
+        echo -e "[storage]\ndriver = \"overlay\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"" | sudo tee /etc/containers/storage.conf
     - name: Install python test deps
       run: |
         # make sure test deps are available for root


### PR DESCRIPTION
This commit moves the GH runner to move to 24.04. This means we no longer need a extra repository to get a current version of podman and it generally means our software stack is more modern and closer to what version people run.

Note that this also drops "podman,skopeo" as those are preinstalled.

Unfortuantely the default 24.04 podman configuration is buggy and a workaround is needed.

[split out from https://github.com/osbuild/bootc-image-builder/pull/689]