### PR TITLE
tests: drop (unsigned) fedora ISO testcase

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -80,7 +80,6 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
         return [
             TestCaseFedora(image="anaconda-iso", sign=True),
             TestCaseCentos(image="anaconda-iso"),
-            TestCaseFedora(image="anaconda-iso"),
         ]
     if what == "qemu-boot":
         test_cases = [


### PR DESCRIPTION
This commit drops the "unsigned" fedora ISO genartion testcases. We also test unsigned ISO generation via centos-9 and we test the fedora ISO generation via the "signed" fedora ISO test so running this specific test gives us little and it is also one of the most "expensive" tests we run (around 10min).