### PR TITLE
bib: add integration test for the new `Disk` customizations

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.7.0
-	github.com/osbuild/images v0.100.1-0.20241122142352-ec6496521e7b
+	github.com/osbuild/images v0.103.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -227,6 +227,8 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/osbuild/images v0.100.1-0.20241122142352-ec6496521e7b h1:zwLef4NPjW6Q0HAjFdwOmsQ5XPNkVRCRm42RPzNBEwM=
 github.com/osbuild/images v0.100.1-0.20241122142352-ec6496521e7b/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
+github.com/osbuild/images v0.103.0 h1:GePI65RK/DPUEjoNqTqvZTdWJtrj+s2NyiLzdNoQYnM=
+github.com/osbuild/images v0.103.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -572,8 +572,10 @@ def test_manifest_disk_customization_lvm(tmp_path, build_container):
                 "partitions": [
                     {
                         "type": "lvm",
+                        "minsize": "10 GiB",
                         "logical_volumes": [
                             {
+                                "minsize": "10 GiB",
                                 "fs_type": "ext4",
                                 "mountpoint": "/",
                             }
@@ -606,6 +608,7 @@ def test_manifest_disk_customization_btrfs(tmp_path, build_container):
                 "partitions": [
                     {
                         "type": "btrfs",
+                        "minsize": "10 GiB",
                         "subvolumes": [
                             {
                                 "name": "root",

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -25,8 +25,8 @@ class TestCase:
     rootfs: str = ""
     # Sign the container_ref and use the new signed image instead of the original one
     sign: bool = False
-    # use special partition_mode like "lvm"
-    partition_mode: str = ""
+    # use special disk_config like "lvm"
+    disk_config: str = ""
 
     def bib_rootfs_args(self):
         if self.rootfs:
@@ -92,9 +92,9 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
         # and custom with raw (this is arbitrary, we could do it the
         # other way around too
         test_cases.append(
-            TestCaseCentos(image="raw", partition_mode="lvm"))
+            TestCaseCentos(image="raw", disk_config="lvm"))
         test_cases.append(
-            TestCaseFedora(image="raw", partition_mode="btrfs"))
+            TestCaseFedora(image="raw", disk_config="btrfs"))
         # do a cross arch test too
         if platform.machine() == "x86_64":
             # TODO: re-enable once


### PR DESCRIPTION
[It is draft right now because it has quite a few rough edges in the code but mostly because the LVM case is not working right now and it's unclear why, but pushing it will help with exposure/feedback, there are also some issues in "images" that are uncovered here that should be fixed there (like minsize seems to be not working for strings)]

This PR adds support for the new `Disk` customizations from https://github.com/osbuild/images/pull/1041 into bib. 

