### PR TITLE
bib: add support for the new Disk customizations

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.7.0
-	github.com/osbuild/images v0.99.0
+	github.com/osbuild/images v0.100.1-0.20241122142352-ec6496521e7b
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -225,8 +225,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/osbuild/images v0.99.0 h1:+L1Di9oP8bK0faYM/Zb2VmxYfFHJq4XWU4KH36e7wkY=
-github.com/osbuild/images v0.99.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
+github.com/osbuild/images v0.100.1-0.20241122142352-ec6496521e7b h1:zwLef4NPjW6Q0HAjFdwOmsQ5XPNkVRCRm42RPzNBEwM=
+github.com/osbuild/images v0.100.1-0.20241122142352-ec6496521e7b/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/package-requires.txt
+++ b/package-requires.txt
@@ -2,7 +2,7 @@
 # from the Containerfile by default, using leading '#' as comments.
 
 # This project uses osbuild
-osbuild osbuild-ostree osbuild-depsolve-dnf
+osbuild osbuild-ostree osbuild-depsolve-dnf osbuild-lvm2
 
 # We mount container images internally
 podman

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -25,6 +25,8 @@ class TestCase:
     rootfs: str = ""
     # Sign the container_ref and use the new signed image instead of the original one
     sign: bool = False
+    # use special partition_mode like "lvm"
+    partition_mode: str = ""
 
     def bib_rootfs_args(self):
         if self.rootfs:
@@ -82,11 +84,17 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             TestCaseCentos(image="anaconda-iso"),
         ]
     if what == "qemu-boot":
+        # test partition defaults with qcow2
         test_cases = [
-            klass(image=img)
+            klass(image="qcow2")
             for klass in (TestCaseCentos, TestCaseFedora)
-            for img in ("raw", "qcow2")
         ]
+        # and custom with raw (this is arbitrary, we could do it the
+        # other way around too
+        test_cases.append(
+            TestCaseCentos(image="raw", partition_mode="lvm"))
+        test_cases.append(
+            TestCaseFedora(image="raw", partition_mode="btrfs"))
         # do a cross arch test too
         if platform.machine() == "x86_64":
             # TODO: re-enable once


### PR DESCRIPTION
This PR adds support for the new Disk customizations from https://github.com/osbuild/images/pull/1041 into bib.

Split from https://github.com/osbuild/bootc-image-builder/pull/721 to allow people to experiment easier, getting the integration test right is a bit tedious.