### PR TITLE
image: run ValidateLayoutConstraints() when using  DiskCustomizations

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -219,6 +219,10 @@ func genPartitionTable(c *ManifestConfig, customizations *blueprint.Customizatio
 }
 
 func genPartitionTableDiskCust(c *ManifestConfig, diskCust *blueprint.DiskCustomization, rng *rand.Rand) (*disk.PartitionTable, error) {
+	if err := diskCust.ValidateLayoutConstraints(); err != nil {
+		return nil, fmt.Errorf("cannot use disk customization: %w", err)
+	}
+
 	diskCust.MinSize = max(diskCust.MinSize, c.RootfsMinsize)
 
 	basept, ok := partitionTables[c.Architecture.String()]

--- a/bib/cmd/bootc-image-builder/image_test.go
+++ b/bib/cmd/bootc-image-builder/image_test.go
@@ -423,3 +423,28 @@ func TestGenPartitionTableSetsRootfsForAllFilesystemsBtrfs(t *testing.T) {
 	mnt, _ = findMountableSizeableFor(pt, "/boot/efi")
 	assert.Equal(t, "vfat", mnt.GetFSType())
 }
+
+func TestGenPartitionTableDiskCustomizationRunsValidateLayoutConstraints(t *testing.T) {
+	rng := bib.CreateRand()
+
+	cnf := &bib.ManifestConfig{
+		Architecture: arch.FromString("amd64"),
+		RootFSType:   "xfs",
+	}
+	cus := &blueprint.Customizations{
+		Disk: &blueprint.DiskCustomization{
+			Partitions: []blueprint.PartitionCustomization{
+				{
+					Type:            "lvm",
+					VGCustomization: blueprint.VGCustomization{},
+				},
+				{
+					Type:            "lvm",
+					VGCustomization: blueprint.VGCustomization{},
+				},
+			},
+		},
+	}
+	_, err := bib.GenPartitionTable(cnf, cus, rng)
+	assert.EqualError(t, err, "cannot use disk customization: multiple LVM volume groups are not yet supported")
+}


### PR DESCRIPTION
This commit will run ValidateLayoutConstraints() when a `DiskCustomization`
is used.

Similar comment to https://github.com/osbuild/images/pull/1063:
