### PR TITLE
Containerfile: disable custom osbuild to test regression

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@ RUN ./build.sh
 
 FROM registry.fedoraproject.org/fedora:40
 # Fast-track osbuild so we don't depend on the "slow" Fedora release process to implement new features in bib
-COPY ./group_osbuild-osbuild-fedora.repo /etc/yum.repos.d/
+#COPY ./group_osbuild-osbuild-fedora.repo /etc/yum.repos.d/
 COPY ./package-requires.txt .
 RUN grep -vE '^#' package-requires.txt | xargs dnf install -y && rm -f package-requires.txt && dnf clean all
 COPY --from=builder /build/bin/* /usr/bin/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # bootc-image-builder
 
+
 A container to create disk images from [bootc](https://github.com/containers/bootc) container inputs,
 especially oriented towards [Fedora/CentOS bootc](https://docs.fedoraproject.org/en-US/bootc/) or
 derivatives.


### PR DESCRIPTION
Test build to just see if new images breaks inegration test with:
```
2024-11-25T20:51:30.8899920Z usermod: user root is currently used by process 7
``` 
(in https://github.com/osbuild/bootc-image-builder/pull/725)