### PR TITLE
HACKING.md: remove unneeded `[`,`]` in the description

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -7,7 +7,7 @@ pytest.
 
 ## Setup
 
-To work on bootc-image-builder one needs a working Go [compiler/environment?]. See
+To work on bootc-image-builder one needs a working Go environment. See
 [go.mod](bib/go.mod). 
 
 To run the testsuite install the test dependencies as outlined in the


### PR DESCRIPTION
This commit removes an unnecessary [] in the description.