### PR TITLE
main,osbuildprogress: add --progress=text,debug support (COMPOSER-2394)

### DIFF
--- a/bib/cmd/bootc-image-builder/cloud.go
+++ b/bib/cmd/bootc-image-builder/cloud.go
@@ -34,7 +34,7 @@ func uploadAMI(path, targetArch string, flags *pflag.FlagSet) error {
 	// similar. Eventually we may provide json progress here too.
 	var pbar *pb.ProgressBar
 	switch progress {
-	case "text":
+	case "", "plain", "term":
 		pbar = pb.New(0)
 	}
 

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -487,6 +487,11 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 
 	pbar.SetMessagef("Build complete!")
 	if upload {
+		// XXX: pass our own progress.ProgressBar here
+		// *for now* just stop our own progress and let the uploadAMI
+		// progress take over - but we really need to fix this in a
+		// followup
+		pbar.Stop()
 		for idx, imgType := range imgTypes {
 			switch imgType {
 			case "ami":

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -244,9 +244,7 @@ func manifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progress
 	}
 
 	pbar.SetPulseMsgf("Manifest generation step")
-	if err := pbar.Start(); err != nil {
-		return nil, nil, fmt.Errorf("cannot start progress: %v", err)
-	}
+	pbar.Start()
 
 	if err := setup.ValidateHasContainerTags(imgref); err != nil {
 		return nil, nil, err
@@ -434,11 +432,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("cannto create progress bar: %w", err)
 	}
-	defer func() {
-		if err := pbar.Stop(); err != nil {
-			logrus.Warnf("progressbar stopping failed: %v", err)
-		}
-	}()
+	defer pbar.Stop()
 
 	manifest_fname := fmt.Sprintf("manifest-%s.json", strings.Join(imgTypes, "-"))
 	pbar.SetMessagef("Generating manifest %s", manifest_fname)

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -21,12 +21,12 @@ import (
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/manifest"
-	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/rpmmd"
 
 	"github.com/osbuild/bootc-image-builder/bib/internal/buildconfig"
 	podman_container "github.com/osbuild/bootc-image-builder/bib/internal/container"
 	"github.com/osbuild/bootc-image-builder/bib/internal/imagetypes"
+	"github.com/osbuild/bootc-image-builder/bib/internal/progress"
 	"github.com/osbuild/bootc-image-builder/bib/internal/setup"
 	"github.com/osbuild/bootc-image-builder/bib/internal/source"
 	"github.com/osbuild/bootc-image-builder/bib/internal/util"
@@ -171,7 +171,16 @@ func saveManifest(ms manifest.OSBuildManifest, fpath string) error {
 	return nil
 }
 
-func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, *mTLSConfig, error) {
+func manifestFromCobra(cmd *cobra.Command, args []string, pbar progress.ProgressBar) ([]byte, *mTLSConfig, error) {
+	if pbar == nil {
+		var err error
+		pbar, err = progress.New("plain")
+		// this should never happen
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	cntArch := arch.Current()
 
 	imgref := args[0]
@@ -232,6 +241,11 @@ func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, *mTLSConfig, 
 		}
 	} else {
 		logrus.Debug("Using local container")
+	}
+
+	pbar.SetPulseMsgf("Manifest generation step")
+	if err := pbar.Start(); err != nil {
+		return nil, nil, fmt.Errorf("cannot start progress: %v", err)
 	}
 
 	if err := setup.ValidateHasContainerTags(imgref); err != nil {
@@ -320,7 +334,7 @@ func manifestFromCobra(cmd *cobra.Command, args []string) ([]byte, *mTLSConfig, 
 }
 
 func cmdManifest(cmd *cobra.Command, args []string) error {
-	mf, _, err := manifestFromCobra(cmd, args)
+	mf, _, err := manifestFromCobra(cmd, args, nil)
 	if err != nil {
 		return fmt.Errorf("cannot generate manifest: %w", err)
 	}
@@ -383,6 +397,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	osbuildStore, _ := cmd.Flags().GetString("store")
 	outputDir, _ := cmd.Flags().GetString("output")
 	targetArch, _ := cmd.Flags().GetString("target-arch")
+	progressType, _ := cmd.Flags().GetString("progress")
 
 	logrus.Debug("Validating environment")
 	if err := setup.Validate(targetArch); err != nil {
@@ -415,13 +430,23 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("chowning is not allowed in output directory")
 	}
 
+	pbar, err := progress.New(progressType)
+	if err != nil {
+		return fmt.Errorf("cannto create progress bar: %w", err)
+	}
+	defer func() {
+		if err := pbar.Stop(); err != nil {
+			logrus.Warnf("progressbar stopping failed: %v", err)
+		}
+	}()
+
 	manifest_fname := fmt.Sprintf("manifest-%s.json", strings.Join(imgTypes, "-"))
-	fmt.Printf("Generating manifest %s\n", manifest_fname)
-	mf, mTLS, err := manifestFromCobra(cmd, args)
+	pbar.SetMessagef("Generating manifest %s", manifest_fname)
+	mf, mTLS, err := manifestFromCobra(cmd, args, pbar)
 	if err != nil {
 		return fmt.Errorf("cannot build manifest: %w", err)
 	}
-	fmt.Print("DONE\n")
+	pbar.SetMessagef("Done generating manifest")
 
 	// collect pipeline exports for each image type
 	imageTypes, err := imagetypes.New(imgTypes...)
@@ -434,7 +459,8 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot save manifest: %w", err)
 	}
 
-	fmt.Printf("Building %s\n", manifest_fname)
+	pbar.SetPulseMsgf("Image building step")
+	pbar.SetMessagef("Building %s", manifest_fname)
 
 	var osbuildEnv []string
 	if !canChown {
@@ -453,12 +479,11 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		osbuildEnv = append(osbuildEnv, envVars...)
 	}
 
-	_, err = osbuild.RunOSBuild(mf, osbuildStore, outputDir, exports, nil, osbuildEnv, false, os.Stderr)
-	if err != nil {
+	if err = progress.RunOSBuild(pbar, mf, osbuildStore, outputDir, exports, osbuildEnv); err != nil {
 		return fmt.Errorf("cannot run osbuild: %w", err)
 	}
 
-	fmt.Println("Build complete!")
+	pbar.SetMessagef("Build complete!")
 	if upload {
 		for idx, imgType := range imgTypes {
 			switch imgType {
@@ -472,7 +497,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 			}
 		}
 	} else {
-		fmt.Printf("Results saved in\n%s\n", outputDir)
+		pbar.SetMessagef("Results saved in %s", outputDir)
 	}
 
 	if err := chownR(outputDir, chown); err != nil {
@@ -607,8 +632,9 @@ func buildCobraCmdline() (*cobra.Command, error) {
 	buildCmd.Flags().String("aws-region", "", "target region for AWS uploads (only for type=ami)")
 	buildCmd.Flags().String("chown", "", "chown the ouput directory to match the specified UID:GID")
 	buildCmd.Flags().String("output", ".", "artifact output directory")
-	buildCmd.Flags().String("progress", "text", "type of progress bar to use")
 	buildCmd.Flags().String("store", "/store", "osbuild store for intermediate pipeline trees")
+	//TODO: add json progress for higher level tools like "podman bootc"
+	buildCmd.Flags().String("progress", "", "type of progress bar to use")
 	// flag rules
 	for _, dname := range []string{"output", "store", "rpmmd"} {
 		if err := buildCmd.MarkFlagDirname(dname); err != nil {

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/letsencrypt/boulder v0.0.0-20240418210053-89b07f4543e0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -190,6 +190,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=

--- a/bib/internal/progress/export_test.go
+++ b/bib/internal/progress/export_test.go
@@ -17,13 +17,3 @@ func MockOsStderr(w io.Writer) (restore func()) {
 		osStderr = saved
 	}
 }
-
-func MockIsattyIsTerminal(b bool) (restore func()) {
-	saved := isattyIsTerminal
-	isattyIsTerminal = func(uintptr) bool {
-		return b
-	}
-	return func() {
-		isattyIsTerminal = saved
-	}
-}

--- a/bib/internal/progress/export_test.go
+++ b/bib/internal/progress/export_test.go
@@ -1,0 +1,29 @@
+package progress
+
+import (
+	"io"
+)
+
+type (
+	TerminalProgressBar = terminalProgressBar
+	DebugProgressBar    = debugProgressBar
+	PlainProgressBar    = plainProgressBar
+)
+
+func MockOsStderr(w io.Writer) (restore func()) {
+	saved := osStderr
+	osStderr = w
+	return func() {
+		osStderr = saved
+	}
+}
+
+func MockIsattyIsTerminal(b bool) (restore func()) {
+	saved := isattyIsTerminal
+	isattyIsTerminal = func(uintptr) bool {
+		return b
+	}
+	return func() {
+		isattyIsTerminal = saved
+	}
+}

--- a/bib/internal/progress/progress.go
+++ b/bib/internal/progress/progress.go
@@ -1,0 +1,309 @@
+package progress
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/cheggaaa/pb/v3"
+	"github.com/mattn/go-isatty"
+	"github.com/sirupsen/logrus"
+
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+var (
+	osStderr         io.Writer = os.Stderr
+	isattyIsTerminal           = isatty.IsTerminal
+)
+
+// ProgressBar is an interface for progress reporting when there is
+// an arbitrary amount of sub-progress information (like osbuild)
+type ProgressBar interface {
+	// SetProgress sets the progress details at the given "level".
+	// Levels should start with "0" and increase as the nesting
+	// gets deeper.
+	SetProgress(level int, msg string, done int, total int) error
+
+	// The high-level message that is displayed in a spinner
+	// that contains the current top level step, for bib this
+	// is really just "Manifest generation step" and
+	// "Image generation step". We could map this to a three-level
+	// progress as well but we spend 90% of the time in the
+	// "Image generation step" so the UI looks a bit odd.
+	SetPulseMsgf(fmt string, args ...interface{})
+
+	// A high level message with the last operation status.
+	// For us this usually comes from the stages and has information
+	// like "Starting module org.osbuild.selinux"
+	SetMessagef(fmt string, args ...interface{})
+	Start() error
+	Stop() error
+}
+
+// New creates a new progressbar based on the requested type
+func New(typ string) (ProgressBar, error) {
+	switch typ {
+	case "", "plain":
+		return NewPlainProgressBar()
+	case "term":
+		return NewTerminalProgressBar()
+	case "debug":
+		return NewDebugProgressBar()
+	default:
+		return nil, fmt.Errorf("unknown progress type: %q", typ)
+	}
+}
+
+type terminalProgressBar struct {
+	spinnerPb   *pb.ProgressBar
+	msgPb       *pb.ProgressBar
+	subLevelPbs []*pb.ProgressBar
+
+	pool        *pb.Pool
+	poolStarted bool
+}
+
+// NewTerminalProgressBar creates a new default pb3 based progressbar suitable for
+// most terminals.
+func NewTerminalProgressBar() (ProgressBar, error) {
+	f, ok := osStderr.(*os.File)
+	if !ok {
+		return nil, fmt.Errorf("cannot use %T as a terminal", f)
+	}
+	if !isattyIsTerminal(f.Fd()) {
+		return nil, fmt.Errorf("cannot use term progress without a terminal")
+	}
+
+	b := &terminalProgressBar{}
+	b.spinnerPb = pb.New(0)
+	b.spinnerPb.SetTemplate(`[{{ (cycle . "|" "/" "-" "\\") }}] {{ string . "spinnerMsg" }}`)
+	b.msgPb = pb.New(0)
+	b.msgPb.SetTemplate(`Message: {{ string . "msg" }}`)
+	b.pool = pb.NewPool(b.spinnerPb, b.msgPb)
+	b.pool.Output = osStderr
+	return b, nil
+}
+
+func (b *terminalProgressBar) SetProgress(subLevel int, msg string, done int, total int) error {
+	// auto-add as needed, requires sublevels to get added in order
+	// i.e. adding 0 and then 2 will fail
+	switch {
+	case subLevel == len(b.subLevelPbs):
+		apb := pb.New(0)
+		b.subLevelPbs = append(b.subLevelPbs, apb)
+		progressBarTmpl := `[{{ counters . }}] {{ string . "prefix" }} {{ bar .}} {{ percent . }}`
+		apb.SetTemplateString(progressBarTmpl)
+		b.pool.Add(apb)
+	case subLevel > len(b.subLevelPbs):
+		return fmt.Errorf("sublevel added out of order, have %v sublevels but want level %v", len(b.subLevelPbs), subLevel)
+	}
+	apb := b.subLevelPbs[subLevel]
+	apb.SetTotal(int64(total) + 1)
+	apb.SetCurrent(int64(done) + 1)
+	if msg != "" {
+		apb.Set("prefix", msg)
+	}
+	return nil
+}
+
+func shorten(msg string) string {
+	msg = strings.Replace(msg, "\n", " ", -1)
+	// XXX: make this smarter
+	if len(msg) > 60 {
+		return msg[:60] + "..."
+	}
+	return msg
+}
+
+func (b *terminalProgressBar) SetPulseMsgf(msg string, args ...interface{}) {
+	b.spinnerPb.Set("spinnerMsg", shorten(fmt.Sprintf(msg, args...)))
+}
+
+func (b *terminalProgressBar) SetMessagef(msg string, args ...interface{}) {
+	b.msgPb.Set("msg", shorten(fmt.Sprintf(msg, args...)))
+}
+
+func (b *terminalProgressBar) Start() error {
+	if err := b.pool.Start(); err != nil {
+		return fmt.Errorf("progress bar failed: %w", err)
+	}
+	b.poolStarted = true
+	return nil
+}
+
+func (b *terminalProgressBar) Stop() (err error) {
+	// pb.Stop() will deadlock if it was not started before
+	if b.poolStarted {
+		err = b.pool.Stop()
+	}
+	b.poolStarted = false
+	return err
+}
+
+type plainProgressBar struct {
+	w io.Writer
+}
+
+// NewPlainProgressBar starts a new "plain" progressbar that will just
+// prints message but does not show any progress.
+func NewPlainProgressBar() (ProgressBar, error) {
+	b := &plainProgressBar{w: osStderr}
+	return b, nil
+}
+
+func (b *plainProgressBar) SetPulseMsgf(msg string, args ...interface{}) {
+	fmt.Fprintf(b.w, msg, args...)
+}
+
+func (b *plainProgressBar) SetMessagef(msg string, args ...interface{}) {
+	fmt.Fprintf(b.w, msg, args...)
+}
+
+func (b *plainProgressBar) Start() (err error) {
+	return nil
+}
+
+func (b *plainProgressBar) Stop() (err error) {
+	return nil
+}
+
+func (b *plainProgressBar) SetProgress(subLevel int, msg string, done int, total int) error {
+	return nil
+}
+
+type debugProgressBar struct {
+	w io.Writer
+}
+
+// NewDebugProgressBar will create a progressbar aimed to debug the
+// lower level osbuild/images message. It will never clear the screen
+// so "glitches/weird" messages from the lower-layers can be inspected
+// easier.
+func NewDebugProgressBar() (ProgressBar, error) {
+	b := &debugProgressBar{w: osStderr}
+	return b, nil
+}
+
+func (b *debugProgressBar) SetPulseMsgf(msg string, args ...interface{}) {
+	fmt.Fprintf(b.w, "pulse: ")
+	fmt.Fprintf(b.w, msg, args...)
+	fmt.Fprintf(b.w, "\n")
+}
+
+func (b *debugProgressBar) SetMessagef(msg string, args ...interface{}) {
+	fmt.Fprintf(b.w, "msg: ")
+	fmt.Fprintf(b.w, msg, args...)
+	fmt.Fprintf(b.w, "\n")
+}
+
+func (b *debugProgressBar) Start() (err error) {
+	fmt.Fprintf(b.w, "Start progressbar\n")
+	return nil
+}
+
+func (b *debugProgressBar) Stop() (err error) {
+	fmt.Fprintf(b.w, "Stop progressbar\n")
+	return nil
+}
+
+func (b *debugProgressBar) SetProgress(subLevel int, msg string, done int, total int) error {
+	fmt.Fprintf(b.w, "%s[%v / %v] %s", strings.Repeat("  ", subLevel), done, total, msg)
+	fmt.Fprintf(b.w, "\n")
+	return nil
+}
+
+// XXX: merge variant back into images/pkg/osbuild/osbuild-exec.go
+func RunOSBuild(pb ProgressBar, manifest []byte, store, outputDirectory string, exports, extraEnv []string) error {
+	// To keep maximum compatibility keep the old behavior to run osbuild
+	// directly and show all messages unless we have a "real" progress bar.
+	//
+	// This should ensure that e.g. "podman bootc" keeps working as it
+	// is currently expecting the raw osbuild output. Once we double
+	// checked with them we can remove the runOSBuildNoProgress() and
+	// just run with the new runOSBuildWithProgress() helper.
+	switch pb.(type) {
+	case *terminalProgressBar, *debugProgressBar:
+		return runOSBuildWithProgress(pb, manifest, store, outputDirectory, exports, extraEnv)
+	default:
+		return runOSBuildNoProgress(pb, manifest, store, outputDirectory, exports, extraEnv)
+	}
+}
+
+func runOSBuildNoProgress(pb ProgressBar, manifest []byte, store, outputDirectory string, exports, extraEnv []string) error {
+	_, err := osbuild.RunOSBuild(manifest, store, outputDirectory, exports, nil, extraEnv, false, os.Stderr)
+	return err
+}
+
+func runOSBuildWithProgress(pb ProgressBar, manifest []byte, store, outputDirectory string, exports, extraEnv []string) error {
+	rp, wp, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("cannot create pipe for osbuild: %w", err)
+	}
+	defer rp.Close()
+	defer wp.Close()
+
+	cmd := exec.Command(
+		"osbuild",
+		"--store", store,
+		"--output-directory", outputDirectory,
+		"--monitor=JSONSeqMonitor",
+		"--monitor-fd=3",
+		"-",
+	)
+	for _, export := range exports {
+		cmd.Args = append(cmd.Args, "--export", export)
+	}
+
+	cmd.Env = append(os.Environ(), extraEnv...)
+	cmd.Stdin = bytes.NewBuffer(manifest)
+	cmd.Stderr = os.Stderr
+	// we could use "--json" here and would get the build-result
+	// exported here
+	cmd.Stdout = nil
+	cmd.ExtraFiles = []*os.File{wp}
+
+	osbuildStatus := osbuild.NewStatusScanner(rp)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("error starting osbuild: %v", err)
+	}
+	wp.Close()
+
+	var tracesMsgs []string
+	for {
+		st, err := osbuildStatus.Status()
+		if err != nil {
+			return fmt.Errorf("error reading osbuild status: %w", err)
+		}
+		if st == nil {
+			break
+		}
+		i := 0
+		for p := st.Progress; p != nil; p = p.SubProgress {
+			if err := pb.SetProgress(i, p.Message, p.Done, p.Total); err != nil {
+				logrus.Warnf("cannot set progress: %v", err)
+			}
+			i++
+		}
+		// keep the messages/traces for better error reporting
+		if st.Message != "" {
+			tracesMsgs = append(tracesMsgs, st.Message)
+		}
+		if st.Trace != "" {
+			tracesMsgs = append(tracesMsgs, st.Trace)
+		}
+		// forward to user
+		if st.Message != "" {
+			pb.SetMessagef(st.Message)
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("error running osbuild: %w\nLog:\n%s", err, strings.Join(tracesMsgs, "\n"))
+	}
+
+	return nil
+}

--- a/bib/internal/progress/progress.go
+++ b/bib/internal/progress/progress.go
@@ -111,12 +111,17 @@ func (b *terminalProgressBar) SetProgress(subLevel int, msg string, done int, to
 	switch {
 	case subLevel == len(b.subLevelPbs):
 		apb := pb.New(0)
-		b.subLevelPbs = append(b.subLevelPbs, apb)
 		progressBarTmpl := `[{{ counters . }}] {{ string . "prefix" }} {{ bar .}} {{ percent . }}`
 		apb.SetTemplateString(progressBarTmpl)
 		if err := apb.Err(); err != nil {
 			return fmt.Errorf("error setting the progressbarTemplat: %w", err)
 		}
+		// workaround bug when running tests in tmt
+		if apb.Width() == 0 {
+			// this is pb.defaultBarWidth
+			apb.SetWidth(100)
+		}
+		b.subLevelPbs = append(b.subLevelPbs, apb)
 	case subLevel > len(b.subLevelPbs):
 		return fmt.Errorf("sublevel added out of order, have %v sublevels but want level %v", len(b.subLevelPbs), subLevel)
 	}

--- a/bib/internal/progress/progress_test.go
+++ b/bib/internal/progress/progress_test.go
@@ -1,0 +1,107 @@
+package progress_test
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/bootc-image-builder/bib/internal/progress"
+)
+
+func TestProgressNew(t *testing.T) {
+	restore := progress.MockIsattyIsTerminal(true)
+	defer restore()
+
+	for _, tc := range []struct {
+		typ         string
+		expected    interface{}
+		expectedErr string
+	}{
+		{"term", &progress.TerminalProgressBar{}, ""},
+		{"debug", &progress.DebugProgressBar{}, ""},
+		{"plain", &progress.PlainProgressBar{}, ""},
+		{"bad", nil, `unknown progress type: "bad"`},
+	} {
+		pb, err := progress.New(tc.typ)
+		if tc.expectedErr == "" {
+			assert.NoError(t, err)
+			assert.Equal(t, reflect.TypeOf(pb), reflect.TypeOf(tc.expected), fmt.Sprintf("[%v] %T not the expected %T", tc.typ, pb, tc.expected))
+		} else {
+			assert.EqualError(t, err, tc.expectedErr)
+		}
+	}
+}
+
+func TestPlainProgress(t *testing.T) {
+	var buf bytes.Buffer
+	restore := progress.MockOsStderr(&buf)
+	defer restore()
+
+	// plain progress never generates progress output
+	pbar, err := progress.NewPlainProgressBar()
+	assert.NoError(t, err)
+	err = pbar.SetProgress(0, "set-progress", 1, 100)
+	assert.NoError(t, err)
+	assert.Equal(t, "", buf.String())
+
+	// but it shows the messages
+	pbar.SetPulseMsgf("pulse")
+	assert.Equal(t, "pulse", buf.String())
+	buf.Reset()
+
+	pbar.SetMessagef("message")
+	assert.Equal(t, "message", buf.String())
+	buf.Reset()
+
+	err = pbar.Start()
+	assert.NoError(t, err)
+	assert.Equal(t, "", buf.String())
+	err = pbar.Stop()
+	assert.NoError(t, err)
+	assert.Equal(t, "", buf.String())
+}
+
+func TestDebugProgress(t *testing.T) {
+	var buf bytes.Buffer
+	restore := progress.MockOsStderr(&buf)
+	defer restore()
+
+	pbar, err := progress.NewDebugProgressBar()
+	assert.NoError(t, err)
+	err = pbar.SetProgress(0, "set-progress-msg", 1, 100)
+	assert.NoError(t, err)
+	assert.Equal(t, "[1 / 100] set-progress-msg\n", buf.String())
+	buf.Reset()
+
+	pbar.SetPulseMsgf("pulse-msg")
+	assert.Equal(t, "pulse: pulse-msg\n", buf.String())
+	buf.Reset()
+
+	pbar.SetMessagef("some-message")
+	assert.Equal(t, "msg: some-message\n", buf.String())
+	buf.Reset()
+
+	err = pbar.Start()
+	assert.NoError(t, err)
+	assert.Equal(t, "Start progressbar\n", buf.String())
+	buf.Reset()
+
+	err = pbar.Stop()
+	assert.NoError(t, err)
+	assert.Equal(t, "Stop progressbar\n", buf.String())
+	buf.Reset()
+}
+
+func TestTermProgressNoTerm(t *testing.T) {
+	var buf bytes.Buffer
+	restore := progress.MockOsStderr(&buf)
+	defer restore()
+
+	// TODO: use something like "github.com/creack/pty" to create
+	// a real pty to test this for real
+	_, err := progress.NewTerminalProgressBar()
+	assert.EqualError(t, err, "cannot use *os.File as a terminal")
+}

--- a/bib/internal/progress/progress_test.go
+++ b/bib/internal/progress/progress_test.go
@@ -103,6 +103,7 @@ func TestTermProgress(t *testing.T) {
 	err = pbar.SetProgress(0, "set-progress-msg", 0, 5)
 	assert.NoError(t, err)
 	pbar.Stop()
+	assert.NoError(t, pbar.(*progress.TerminalProgressBar).Err())
 
 	assert.Contains(t, buf.String(), "[1 / 6] set-progress-msg")
 	assert.Contains(t, buf.String(), "[|] pulse-msg\n")

--- a/bib/internal/progress/progress_test.go
+++ b/bib/internal/progress/progress_test.go
@@ -54,11 +54,9 @@ func TestPlainProgress(t *testing.T) {
 	assert.Equal(t, "message", buf.String())
 	buf.Reset()
 
-	err = pbar.Start()
-	assert.NoError(t, err)
+	pbar.Start()
 	assert.Equal(t, "", buf.String())
-	err = pbar.Stop()
-	assert.NoError(t, err)
+	pbar.Stop()
 	assert.Equal(t, "", buf.String())
 }
 
@@ -82,13 +80,11 @@ func TestDebugProgress(t *testing.T) {
 	assert.Equal(t, "msg: some-message\n", buf.String())
 	buf.Reset()
 
-	err = pbar.Start()
-	assert.NoError(t, err)
+	pbar.Start()
 	assert.Equal(t, "Start progressbar\n", buf.String())
 	buf.Reset()
 
-	err = pbar.Stop()
-	assert.NoError(t, err)
+	pbar.Stop()
 	assert.Equal(t, "Stop progressbar\n", buf.String())
 	buf.Reset()
 }
@@ -101,14 +97,12 @@ func TestTermProgress(t *testing.T) {
 	pbar, err := progress.NewTerminalProgressBar()
 	assert.NoError(t, err)
 
-	err = pbar.Start()
-	assert.NoError(t, err)
+	pbar.Start()
 	pbar.SetPulseMsgf("pulse-msg")
 	pbar.SetMessagef("some-message")
 	err = pbar.SetProgress(0, "set-progress-msg", 0, 5)
 	assert.NoError(t, err)
-	err = pbar.Stop()
-	assert.NoError(t, err)
+	pbar.Stop()
 
 	assert.Contains(t, buf.String(), "[1 / 6] set-progress-msg")
 	assert.Contains(t, buf.String(), "[|] pulse-msg\n")

--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -68,16 +68,15 @@ def build_fake_container_fixture(tmpdir_factory, build_container):
 
     fake_osbuild_path = tmp_path / "fake-osbuild"
     fake_osbuild_path.write_text(textwrap.dedent("""\
-    #!/bin/sh -e
+    #!/bin/bash -e
 
     # injest generated manifest from the images library, if we do not
     # do this images may fail with "broken" pipe errors
-    cat -
+    cat - >/dev/null
 
     mkdir -p /output/qcow2
     echo "fake-disk.qcow2" > /output/qcow2/disk.qcow2
 
-    echo "Done"
     """), encoding="utf8")
 
     cntf_path = tmp_path / "Containerfile"

--- a/test/test_progress.py
+++ b/test/test_progress.py
@@ -1,12 +1,15 @@
 import subprocess
 
-# pylint: disable=unused-import
+# pylint: disable=unused-import,duplicate-code
 from test_opts import container_storage_fixture
 from containerbuild import build_container_fixture, build_fake_container_fixture
 
 
-def bib_cmd(container_storage, output_path, build_fake_container):
-    return [
+def test_progress_debug(tmp_path, container_storage, build_fake_container):
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+
+    cmdline = [
         "podman", "run", "--rm",
         "--privileged",
         "--security-opt", "label=type:unconfined_t",
@@ -16,13 +19,6 @@ def bib_cmd(container_storage, output_path, build_fake_container):
         "build",
         "quay.io/centos-bootc/centos-bootc:stream9",
     ]
-
-
-def test_progress_debug(tmp_path, container_storage, build_fake_container):
-    output_path = tmp_path / "output"
-    output_path.mkdir(exist_ok=True)
-
-    cmdline = bib_cmd(container_storage, output_path, build_fake_container)
     cmdline.append("--progress=debug")
     res = subprocess.run(cmdline, capture_output=True, check=True, text=True)
     assert res.stderr.count("Start progressbar") == 1
@@ -31,3 +27,24 @@ def test_progress_debug(tmp_path, container_storage, build_fake_container):
     assert res.stderr.count("Build complete") == 1
     assert res.stderr.count("Stop progressbar") == 1
     assert res.stdout.strip() == ""
+
+
+def test_progress_term(tmp_path, container_storage, build_fake_container):
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+
+    cmdline = [
+        "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
+        "-v", f"{container_storage}:/var/lib/containers/storage",
+        "-v", f"{output_path}:/output",
+        build_fake_container,
+        "build",
+        # explicitly select term progress
+        "--progress=term",
+        "quay.io/centos-bootc/centos-bootc:stream9",
+    ]
+    res = subprocess.run(cmdline, capture_output=True, text=True, check=False)
+    assert res.returncode == 0
+    assert "[|] Manifest generation step" in res.stderr

--- a/test/test_progress.py
+++ b/test/test_progress.py
@@ -1,0 +1,33 @@
+import subprocess
+
+# pylint: disable=unused-import
+from test_opts import container_storage_fixture
+from containerbuild import build_container_fixture, build_fake_container_fixture
+
+
+def bib_cmd(container_storage, output_path, build_fake_container):
+    return [
+        "podman", "run", "--rm",
+        "--privileged",
+        "--security-opt", "label=type:unconfined_t",
+        "-v", f"{container_storage}:/var/lib/containers/storage",
+        "-v", f"{output_path}:/output",
+        build_fake_container,
+        "build",
+        "quay.io/centos-bootc/centos-bootc:stream9",
+    ]
+
+
+def test_progress_debug(tmp_path, container_storage, build_fake_container):
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+
+    cmdline = bib_cmd(container_storage, output_path, build_fake_container)
+    cmdline.append("--progress=debug")
+    res = subprocess.run(cmdline, capture_output=True, check=True, text=True)
+    assert res.stderr.count("Start progressbar") == 1
+    assert res.stderr.count("Manifest generation step") == 1
+    assert res.stderr.count("Image building step") == 1
+    assert res.stderr.count("Build complete") == 1
+    assert res.stderr.count("Stop progressbar") == 1
+    assert res.stdout.strip() == ""


### PR DESCRIPTION
This adds a new `progress` flag that makes use of the
osbuild jsonseq progress information to show progress and
hide the low-level details from the user.

Here is what it looks like:
https://asciinema.org/a/cJpB6066UoDDzAylwHVHjEEIN

(c.f. COMPOSER-2394)
