### PR TITLE
test: add integration test for the new `swap` customization

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.7.0
-	github.com/osbuild/images v0.103.0
+	github.com/osbuild/images v0.104.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -225,8 +225,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/osbuild/images v0.103.0 h1:GePI65RK/DPUEjoNqTqvZTdWJtrj+s2NyiLzdNoQYnM=
-github.com/osbuild/images v0.103.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
+github.com/osbuild/images v0.104.0 h1:EXEykPxQE5VNuLH/QM3NTYjgtIWlltPhiEQEg+DBCnI=
+github.com/osbuild/images v0.104.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -84,17 +84,14 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             TestCaseCentos(image="anaconda-iso"),
         ]
     if what == "qemu-boot":
-        # test partition defaults with qcow2
         test_cases = [
-            klass(image="qcow2")
-            for klass in (TestCaseCentos, TestCaseFedora)
+            # test default partitioning
+            TestCaseFedora(image="qcow2"),
+            # test with custom disk configs
+            TestCaseCentos(image="qcow2", disk_config="swap"),
+            TestCaseFedora(image="raw", disk_config="btrfs"),
+            TestCaseCentos(image="raw", disk_config="lvm"),
         ]
-        # and custom with raw (this is arbitrary, we could do it the
-        # other way around too
-        test_cases.append(
-            TestCaseCentos(image="raw", disk_config="lvm"))
-        test_cases.append(
-            TestCaseFedora(image="raw", disk_config="btrfs"))
         # do a cross arch test too
         if platform.machine() == "x86_64":
             # TODO: re-enable once

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -159,6 +159,10 @@ def maybe_create_disk_customizations(cfg, tc):
                             "minsize": "10 GiB",
                             "fs_type": "xfs",
                             "mountpoint": "/",
+                        },
+                        {
+                            "minsize": "7 GiB",
+                            "fs_type": "swap",
                         }
                     ]
                 }
@@ -176,6 +180,15 @@ def maybe_create_disk_customizations(cfg, tc):
                             "mountpoint": "/var/log",
                         }
                     ]
+                }
+            ]
+        }
+    elif tc.disk_config == "swap":
+        cfg["customizations"]["disk"] = {
+            "partitions": [
+                {
+                    "minsize": "123 MiB",
+                    "fs_type": "swap",
                 }
             ]
         }


### PR DESCRIPTION
This commit adds an integration test for the new swap disk customization that got added to the `images` library in PR https://github.com/osbuild/images/pull/1072

