### PR TITLE
test: add regression test/fix for gh748 swap space creation

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/customizations/users"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
@@ -234,11 +235,18 @@ func genPartitionTableDiskCust(c *ManifestConfig, diskCust *blueprint.DiskCustom
 		return nil, err
 	}
 
+	// XXX: copied from images, take from container instead?
+	requiredDirectorySizes := map[string]uint64{
+		"/":    1 * datasizes.GiB,
+		"/usr": 2 * datasizes.GiB,
+	}
 	partOptions := &disk.CustomPartitionTableOptions{
 		PartitionTableType: basept.Type,
 		// XXX: not setting/defaults will fail to boot with btrfs/lvm
 		BootMode:      platform.BOOT_HYBRID,
 		DefaultFSType: defaultFSType,
+		// ensure sensible defaults for /,/usr
+		RequiredMinSizes: requiredDirectorySizes,
 	}
 	return disk.NewCustomPartitionTable(diskCust, partOptions, rng)
 }

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -725,3 +725,9 @@ def test_manifest_disk_customization_lvm_swap(tmp_path, build_container):
         "path": "none",
         "options": "defaults",
     } in filesystems
+    # run osbuild schema validation, see gh#748
+    if not testutil.has_executable("osbuild"):
+        pytest.skip("no osbuild executable")
+    osbuild_manifest_path = tmp_path / "manifest.json"
+    osbuild_manifest_path.write_bytes(output)
+    subprocess.run(["osbuild", osbuild_manifest_path.as_posix()], check=True)

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -156,9 +156,9 @@ def maybe_create_disk_customizations(cfg, tc):
                     "minsize": "10 GiB",
                     "logical_volumes": [
                         {
-                            "minsize": "10 GiB",
                             "fs_type": "xfs",
-                            "mountpoint": "/",
+                            "minsize": "1 GiB",
+                            "mountpoint": "/var/log",
                         },
                         {
                             "minsize": "7 GiB",


### PR DESCRIPTION
This commit adds a regression test for the manifest creation when custom disk are used. When just adding a swap device the rootlv size is not set/updated correctly which leads to a manifest like:
```json
...
        {
          "type": "org.osbuild.lvm2.create",
          "options": {
            "volumes": [
              {
                "name": "swaplv",
                "size": "2147483648B"
              },
              {
                "name": "rootlv",
                "size": "0B"
              }
            ]
          },
...
```
for a config like:
```json
"customizations": {
            "disk": {
                "partitions": [
                    {
                        "type": "lvm",
                        "minsize": "10 GiB",
                        "logical_volumes": [
                            {
                                "minsize": "2 GiB",
                                "fs_type": "swap",
                            }
                        ]
                    }
                ]
            }
```
and indeed, we test that config in our unit tests (test_manifest_disk_customization_lvm_swa) but we do not run the full osbuild validation on it :(

Closes: https://github.com/osbuild/bootc-image-builder/issues/748