### PR TITLE
bib: improve the "/" size calculation for LVM

### DIFF
--- a/bib/cmd/bootc-image-builder/export_test.go
+++ b/bib/cmd/bootc-image-builder/export_test.go
@@ -10,6 +10,7 @@ var (
 	GenPartitionTable             = genPartitionTable
 	CreateRand                    = createRand
 	BuildCobraCmdline             = buildCobraCmdline
+	CalcRequiredDirectorySizes    = calcRequiredDirectorySizes
 )
 
 func MockOsGetuid(new func() int) (restore func()) {

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/customizations/users"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
@@ -234,11 +235,18 @@ func genPartitionTableDiskCust(c *ManifestConfig, diskCust *blueprint.DiskCustom
 		return nil, err
 	}
 
+	// XXX: copied from images, take from container instead?
+	requiredDirectorySizes := map[string]uint64{
+		"/":    1 * datasizes.GiB,
+		"/usr": 2 * datasizes.GiB,
+	}
 	partOptions := &disk.CustomPartitionTableOptions{
 		PartitionTableType: basept.Type,
 		// XXX: not setting/defaults will fail to boot with btrfs/lvm
 		BootMode:      platform.BOOT_HYBRID,
 		DefaultFSType: defaultFSType,
+		// ensure sensible defaults for /,/usr
+		RequiredMinSizes: requiredDirectorySizes,
 	}
 	return disk.NewCustomPartitionTable(diskCust, partOptions, rng)
 }

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.7.0
-	github.com/osbuild/images v0.104.0
+	github.com/osbuild/images v0.105.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -225,8 +225,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/osbuild/images v0.104.0 h1:EXEykPxQE5VNuLH/QM3NTYjgtIWlltPhiEQEg+DBCnI=
-github.com/osbuild/images v0.104.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
+github.com/osbuild/images v0.105.0 h1:KVFKmBhxDzpdZuzLfM84TpfNP40feC5DjRKn+OJcOZ8=
+github.com/osbuild/images v0.105.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -725,3 +725,9 @@ def test_manifest_disk_customization_lvm_swap(tmp_path, build_container):
         "path": "none",
         "options": "defaults",
     } in filesystems
+    # run osbuild schema validation, see gh#748
+    if not testutil.has_executable("osbuild"):
+        pytest.skip("no osbuild executable")
+    osbuild_manifest_path = tmp_path / "manifest.json"
+    osbuild_manifest_path.write_bytes(output)
+    subprocess.run(["osbuild", osbuild_manifest_path.as_posix()], check=True)

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -156,9 +156,9 @@ def maybe_create_disk_customizations(cfg, tc):
                     "minsize": "10 GiB",
                     "logical_volumes": [
                         {
-                            "minsize": "10 GiB",
                             "fs_type": "xfs",
-                            "mountpoint": "/",
+                            "minsize": "1 GiB",
+                            "mountpoint": "/var/log",
                         },
                         {
                             "minsize": "7 GiB",


### PR DESCRIPTION
This commit improves the rootfs size calculation for advanced
partitioning.  Just like for the tranditional filesystem
customization where we use `updateFilesystemSizes()` to ensure
that the rootfs is at least the two times size of the container
we need to do the same for the advanced disk partitioning.

The disk library will need a `RequiredMinSizes` parameter
(see gh#748) to know what sizes to pick. So far we did not
pass this which can leads to a "0B" root partition.

The naive fix was to just include a hardcoded:
```
requiredDirectorySizes = map[string]uint64{
        "/":    1 * datasizes.GiB,
        "/usr": 2 * datasizes.GiB,
}
```
but of course that is not ideal because we calculate the
size of disk based on 2x the container size. We set this
for the rootfs so the entire disk is big enough. However
because in advanced partitioning "/" is not automatically
expanded we end up with a potentially too small "/".

This commit tweaks the calculcation so that it sets the
requiredDirectorySizes for "/" to be at least 2x container
size.

Note that a custom "/usr" is not supported in image mode so splitting
rootfsMinSize between / and /usr is not a concern.

Closes: https://github.com/osbuild/bootc-image-builder/issues/748