### PR TITLE
Add manifests for Alma Linux 9 and 10

### DIFF
--- a/bib/data/defs/almalinux-10.yaml
+++ b/bib/data/defs/almalinux-10.yaml
@@ -1,0 +1,1 @@
+centos-10.yaml

--- a/bib/data/defs/almalinux-9.yaml
+++ b/bib/data/defs/almalinux-9.yaml
@@ -1,0 +1,1 @@
+centos-9.yaml


### PR DESCRIPTION
Makes it possible to build images based on Alma Linux bootc containers, such as `quay.io/almalinuxorg/almalinux-bootc:9.5`

Fixes #753