### PR TITLE
github/actions: Enable /jira-epic slash commands (HMS-5161)

### DIFF
--- a/.github/workflows/pr_best_practices.yml
+++ b/.github/workflows/pr_best_practices.yml
@@ -1,0 +1,18 @@
+name: "Verify PR best practices"
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+  issue_comment:
+    types: [created]
+
+jobs:
+  pr-best-practices:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR best practice check
+        uses: osbuild/pr-best-practices@main
+        with:
+          token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+          jira_token: ${{ secrets.IMAGEBUILDER_BOT_JIRA_TOKEN }}


### PR DESCRIPTION
This change allows for using the command to create Jira Tasks under a given Epic both in a pull request comment or in the pull request description.

To use the action, you can simply add a comment to a given pull request with the following content:
`/jira-epic ISSUE-1234`

This will trigger the action and a bot will create a Jira Task under the Epic ISSUE-1234. Once this is successful, it will update the pull request title and description to contain a link to the newly created Jira ticket, which also means that the two will be linked.
Alternatively, you can also add the command to the pull request description (if you e.g. want to create the Task at PR creation time).

Note: This is currently only enabled for the HMS project.