### PR TITLE
progress: fix missing "\n" in plain progress

### DIFF
--- a/bib/internal/progress/progress.go
+++ b/bib/internal/progress/progress.go
@@ -246,10 +246,12 @@ func NewPlainProgressBar() (ProgressBar, error) {
 
 func (b *plainProgressBar) SetPulseMsgf(msg string, args ...interface{}) {
 	fmt.Fprintf(b.w, msg, args...)
+	fmt.Fprintf(b.w, "\n")
 }
 
 func (b *plainProgressBar) SetMessagef(msg string, args ...interface{}) {
 	fmt.Fprintf(b.w, msg, args...)
+	fmt.Fprintf(b.w, "\n")
 }
 
 func (b *plainProgressBar) Start() {

--- a/bib/internal/progress/progress_test.go
+++ b/bib/internal/progress/progress_test.go
@@ -47,11 +47,11 @@ func TestPlainProgress(t *testing.T) {
 
 	// but it shows the messages
 	pbar.SetPulseMsgf("pulse")
-	assert.Equal(t, "pulse", buf.String())
+	assert.Equal(t, "pulse\n", buf.String())
 	buf.Reset()
 
 	pbar.SetMessagef("message")
-	assert.Equal(t, "message", buf.String())
+	assert.Equal(t, "message\n", buf.String())
 	buf.Reset()
 
 	pbar.Start()


### PR DESCRIPTION
This commit fixes the missing \n when plain progress is used. Without the output looks rather silly :/