### PR TITLE
progress: auto-select progress based on the environment

### DIFF
--- a/bib/internal/progress/export_test.go
+++ b/bib/internal/progress/export_test.go
@@ -17,3 +17,11 @@ func MockOsStderr(w io.Writer) (restore func()) {
 		osStderr = saved
 	}
 }
+
+func MockIsattyIsTerminal(fn func(uintptr) bool) (restore func()) {
+	saved := isattyIsTerminal
+	isattyIsTerminal = fn
+	return func() {
+		isattyIsTerminal = saved
+	}
+}

--- a/bib/internal/progress/progress.go
+++ b/bib/internal/progress/progress.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
+	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 
 	"github.com/osbuild/images/pkg/osbuild"
@@ -66,12 +67,19 @@ type ProgressBar interface {
 	Stop()
 }
 
+var isattyIsTerminal = isatty.IsTerminal
+
 // New creates a new progressbar based on the requested type
 func New(typ string) (ProgressBar, error) {
 	switch typ {
-	// XXX: autoseelct based on PS1 value (i.e. use term in
-	// interactive shells only?)
-	case "", "plain":
+	case "":
+		// autoselect based on if we are on an interactive
+		// terminal, use plain progress for scripts
+		if isattyIsTerminal(os.Stdin.Fd()) {
+			return NewTerminalProgressBar()
+		}
+		return NewPlainProgressBar()
+	case "plain":
 		return NewPlainProgressBar()
 	case "term":
 		return NewTerminalProgressBar()

--- a/bib/internal/progress/progress_test.go
+++ b/bib/internal/progress/progress_test.go
@@ -111,3 +111,22 @@ func TestTermProgress(t *testing.T) {
 	// check shutdown
 	assert.Contains(t, buf.String(), progress.CURSOR_SHOW)
 }
+
+func TestProgressNewAutoselect(t *testing.T) {
+	for _, tc := range []struct {
+		onTerm   bool
+		expected interface{}
+	}{
+		{false, &progress.PlainProgressBar{}},
+		{true, &progress.TerminalProgressBar{}},
+	} {
+		restore := progress.MockIsattyIsTerminal(func(uintptr) bool {
+			return tc.onTerm
+		})
+		defer restore()
+
+		pb, err := progress.New("")
+		assert.NoError(t, err)
+		assert.Equal(t, reflect.TypeOf(pb), reflect.TypeOf(tc.expected), fmt.Sprintf("[%v] %T not the expected %T", tc.onTerm, pb, tc.expected))
+	}
+}


### PR DESCRIPTION
This commit adds automatic progress bar selection based on checking
if we run on a terminal or not. When running on a terminal we use
the nice "terminalProgressBar". If that is not set we assuem
we run in a script or CI/CD environment and select plainProgressBar.

Thanks Colin for the hint about the bad integration test.
