### PR TITLE
test: disable the fedora iso test for now

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -87,7 +87,9 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
         return [TestCaseC9S(image="ami"), TestCaseFedora(image="ami")]
     if what == "anaconda-iso":
         return [
-            TestCaseFedora(image="anaconda-iso", sign=True),
+            # 2024-12-19: disabled for now until the mirror situation becomes
+            # a bit more stable
+            # TestCaseFedora(image="anaconda-iso", sign=True),
             TestCaseC9S(image="anaconda-iso"),
             TestCaseC10S(image="anaconda-iso"),
         ]


### PR DESCRIPTION
This commit disables the fedora ISO test for now. The download of the RPMs tends to be very fragile, often mirrors are outdated or broken and we get many 404 or 500 errors.

The real fix is of couse to switch to a librepo based downloading in osbuild but for now we just disable this test so that we can merge PRs again without having to retry multiple times :(