### PR TITLE
main,README: improve docs around `--progress`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Usage:
 Flags:
       --chown string           chown the ouput directory to match the specified UID:GID
       --tls-verify             require HTTPS and verify certificates when contacting registries (default true)
+      --progress string        type of progress bar to use (e.g. plain,term)
       --type string            image type to build [qcow2, ami] (default "qcow2")
       --target-arch string     architecture to build image for (default is the native architecture)
 ```
@@ -137,6 +138,7 @@ Flags:
 | Argument          | Description                                                                                               | Default Value |
 |-------------------|-----------------------------------------------------------------------------------------------------------|:-------------:|
 | **--chown**       | chown the output directory to match the specified UID:GID                                                 |       ❌      |
+| **--progress**   | Show progress in the given format, supported: plain,term,debug. If empty it is auto-detected               |       ❌      |
 | **--rootfs**      | Root filesystem type. Overrides the default from the source container. Supported values: ext4, xfs, btrfs |       ❌      |
 | **--tls-verify**  | Require HTTPS and verify certificates when contacting registries                                          |    `true`     |
 | **--type**        | [Image type](#-image-types) to build                                                                      |    `qcow2`    |
@@ -171,6 +173,16 @@ The architecture of the bootc OCI image and the bootc-image-builder image must m
 a non-native architecture bootc OCI image, say, building for x86_64 from an arm-based Mac, it is possible to run
 `podman build` with the `--platform linux/amd64` flag. In this case, to then build a disk image from the same arm-based Mac,
 you should provide `--target-arch amd64` when running the `bootc-image-builder` command.
+
+## Progress types
+
+The following progress types are supported:
+
+* plain: No spinners or progress bar, just information and full osbuild output
+* term: Terminal based output, spinner, progressbar and most details of osbuild are hidden
+* debug: Details how the progress is called, mostly useful for bugreports
+
+Note that when no value is given the progress is auto-detected baed on the environment. When `stdin` is a terminal the "term" progress is used, otherwise "plain". The output of `plain` is exactaly the same as it was before progress reporting was implemented.
 
 ## ☁️ Cloud uploaders
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Usage:
 Flags:
       --chown string           chown the ouput directory to match the specified UID:GID
       --tls-verify             require HTTPS and verify certificates when contacting registries (default true)
-      --progress string        type of progress bar to use (e.g. plain,term)
+      --progress string        type of progress bar to use (e.g. verbose, term)
       --type string            image type to build [qcow2, ami] (default "qcow2")
       --target-arch string     architecture to build image for (default is the native architecture)
 ```
@@ -138,7 +138,7 @@ Flags:
 | Argument          | Description                                                                                               | Default Value |
 |-------------------|-----------------------------------------------------------------------------------------------------------|:-------------:|
 | **--chown**       | chown the output directory to match the specified UID:GID                                                 |       ❌      |
-| **--progress**   | Show progress in the given format, supported: plain,term,debug. If empty it is auto-detected               |   `auto`      |
+| **--progress**   | Show progress in the given format, supported: verbose,term,debug. If empty it is auto-detected               |   `auto`      |
 | **--rootfs**      | Root filesystem type. Overrides the default from the source container. Supported values: ext4, xfs, btrfs |       ❌      |
 | **--tls-verify**  | Require HTTPS and verify certificates when contacting registries                                          |    `true`     |
 | **--type**        | [Image type](#-image-types) to build                                                                      |    `qcow2`    |
@@ -178,11 +178,11 @@ you should provide `--target-arch amd64` when running the `bootc-image-builder` 
 
 The following progress types are supported:
 
-* plain: No spinners or progress bar, just information and full osbuild output
+* verbose: No spinners or progress bar, just information and full osbuild output
 * term: Terminal based output, spinner, progressbar and most details of osbuild are hidden
 * debug: Details how the progress is called, mostly useful for bugreports
 
-Note that when no value is given the progress is auto-detected baed on the environment. When `stdin` is a terminal the "term" progress is used, otherwise "plain". The output of `plain` is exactaly the same as it was before progress reporting was implemented.
+Note that when no value is given the progress is auto-detected baed on the environment. When `stdin` is a terminal the "term" progress is used, otherwise "verbose". The output of `verbose` is exactaly the same as it was before progress reporting was implemented.
 
 ## ☁️ Cloud uploaders
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Flags:
 | Argument          | Description                                                                                               | Default Value |
 |-------------------|-----------------------------------------------------------------------------------------------------------|:-------------:|
 | **--chown**       | chown the output directory to match the specified UID:GID                                                 |       ❌      |
-| **--progress**   | Show progress in the given format, supported: plain,term,debug. If empty it is auto-detected               |       ❌      |
+| **--progress**   | Show progress in the given format, supported: plain,term,debug. If empty it is auto-detected               |   `auto`      |
 | **--rootfs**      | Root filesystem type. Overrides the default from the source container. Supported values: ext4, xfs, btrfs |       ❌      |
 | **--tls-verify**  | Require HTTPS and verify certificates when contacting registries                                          |    `true`     |
 | **--type**        | [Image type](#-image-types) to build                                                                      |    `qcow2`    |

--- a/bib/cmd/bootc-image-builder/cloud.go
+++ b/bib/cmd/bootc-image-builder/cloud.go
@@ -34,7 +34,7 @@ func uploadAMI(path, targetArch string, flags *pflag.FlagSet) error {
 	// similar. Eventually we may provide json progress here too.
 	var pbar *pb.ProgressBar
 	switch progress {
-	case "", "plain", "term":
+	case "auto", "verbose", "term":
 		pbar = pb.New(0)
 	}
 

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -646,7 +646,7 @@ func buildCobraCmdline() (*cobra.Command, error) {
 	buildCmd.Flags().String("output", ".", "artifact output directory")
 	buildCmd.Flags().String("store", "/store", "osbuild store for intermediate pipeline trees")
 	//TODO: add json progress for higher level tools like "podman bootc"
-	buildCmd.Flags().String("progress", "auto", "type of progress bar to use (e.g. plain,term)")
+	buildCmd.Flags().String("progress", "auto", "type of progress bar to use (e.g. verbose,term)")
 	// flag rules
 	for _, dname := range []string{"output", "store", "rpmmd"} {
 		if err := buildCmd.MarkFlagDirname(dname); err != nil {

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -646,7 +646,7 @@ func buildCobraCmdline() (*cobra.Command, error) {
 	buildCmd.Flags().String("output", ".", "artifact output directory")
 	buildCmd.Flags().String("store", "/store", "osbuild store for intermediate pipeline trees")
 	//TODO: add json progress for higher level tools like "podman bootc"
-	buildCmd.Flags().String("progress", "", "type of progress bar to use")
+	buildCmd.Flags().String("progress", "", "type of progress bar to use (e.g. plain,term)")
 	// flag rules
 	for _, dname := range []string{"output", "store", "rpmmd"} {
 		if err := buildCmd.MarkFlagDirname(dname); err != nil {

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -594,9 +594,9 @@ func buildCobraCmdline() (*cobra.Command, error) {
 	rootCmd.PersistentFlags().StringVar(&rootLogLevel, "log-level", "", "logging level (debug, info, error); default error")
 
 	buildCmd := &cobra.Command{
-		Use:                   "build IMAGE_NAME",
-		Short:                 rootCmd.Long + " (default command)",
-		Long:                  rootCmd.Long + "\n" +
+		Use:   "build IMAGE_NAME",
+		Short: rootCmd.Long + " (default command)",
+		Long: rootCmd.Long + "\n" +
 			"(default action if no command is given)\n" +
 			"IMAGE_NAME: container image to build into a bootable image",
 		Args:                  cobra.ExactArgs(1),
@@ -646,7 +646,7 @@ func buildCobraCmdline() (*cobra.Command, error) {
 	buildCmd.Flags().String("output", ".", "artifact output directory")
 	buildCmd.Flags().String("store", "/store", "osbuild store for intermediate pipeline trees")
 	//TODO: add json progress for higher level tools like "podman bootc"
-	buildCmd.Flags().String("progress", "", "type of progress bar to use (e.g. plain,term)")
+	buildCmd.Flags().String("progress", "auto", "type of progress bar to use (e.g. plain,term)")
 	// flag rules
 	for _, dname := range []string{"output", "store", "rpmmd"} {
 		if err := buildCmd.MarkFlagDirname(dname); err != nil {

--- a/bib/internal/progress/export_test.go
+++ b/bib/internal/progress/export_test.go
@@ -7,7 +7,7 @@ import (
 type (
 	TerminalProgressBar = terminalProgressBar
 	DebugProgressBar    = debugProgressBar
-	PlainProgressBar    = plainProgressBar
+	VerboseProgressBar  = verboseProgressBar
 )
 
 func MockOsStderr(w io.Writer) (restore func()) {

--- a/bib/internal/progress/progress.go
+++ b/bib/internal/progress/progress.go
@@ -74,13 +74,13 @@ func New(typ string) (ProgressBar, error) {
 	switch typ {
 	case "", "auto":
 		// autoselect based on if we are on an interactive
-		// terminal, use plain progress for scripts
+		// terminal, use verbose progress for scripts
 		if isattyIsTerminal(os.Stdin.Fd()) {
 			return NewTerminalProgressBar()
 		}
-		return NewPlainProgressBar()
-	case "plain":
-		return NewPlainProgressBar()
+		return NewVerboseProgressBar()
+	case "verbose":
+		return NewVerboseProgressBar()
 	case "term":
 		return NewTerminalProgressBar()
 	case "debug":
@@ -241,34 +241,34 @@ func (b *terminalProgressBar) Stop() {
 	}
 }
 
-type plainProgressBar struct {
+type verboseProgressBar struct {
 	w io.Writer
 }
 
-// NewPlainProgressBar starts a new "plain" progressbar that will just
+// NewVerboseProgressBar starts a new "verbose" progressbar that will just
 // prints message but does not show any progress.
-func NewPlainProgressBar() (ProgressBar, error) {
-	b := &plainProgressBar{w: osStderr}
+func NewVerboseProgressBar() (ProgressBar, error) {
+	b := &verboseProgressBar{w: osStderr}
 	return b, nil
 }
 
-func (b *plainProgressBar) SetPulseMsgf(msg string, args ...interface{}) {
+func (b *verboseProgressBar) SetPulseMsgf(msg string, args ...interface{}) {
 	fmt.Fprintf(b.w, msg, args...)
 	fmt.Fprintf(b.w, "\n")
 }
 
-func (b *plainProgressBar) SetMessagef(msg string, args ...interface{}) {
+func (b *verboseProgressBar) SetMessagef(msg string, args ...interface{}) {
 	fmt.Fprintf(b.w, msg, args...)
 	fmt.Fprintf(b.w, "\n")
 }
 
-func (b *plainProgressBar) Start() {
+func (b *verboseProgressBar) Start() {
 }
 
-func (b *plainProgressBar) Stop() {
+func (b *verboseProgressBar) Stop() {
 }
 
-func (b *plainProgressBar) SetProgress(subLevel int, msg string, done int, total int) error {
+func (b *verboseProgressBar) SetProgress(subLevel int, msg string, done int, total int) error {
 	return nil
 }
 

--- a/bib/internal/progress/progress.go
+++ b/bib/internal/progress/progress.go
@@ -72,7 +72,7 @@ var isattyIsTerminal = isatty.IsTerminal
 // New creates a new progressbar based on the requested type
 func New(typ string) (ProgressBar, error) {
 	switch typ {
-	case "":
+	case "", "auto":
 		// autoselect based on if we are on an interactive
 		// terminal, use plain progress for scripts
 		if isattyIsTerminal(os.Stdin.Fd()) {

--- a/bib/internal/progress/progress_test.go
+++ b/bib/internal/progress/progress_test.go
@@ -125,7 +125,7 @@ func TestProgressNewAutoselect(t *testing.T) {
 		})
 		defer restore()
 
-		pb, err := progress.New("")
+		pb, err := progress.New("auto")
 		assert.NoError(t, err)
 		assert.Equal(t, reflect.TypeOf(pb), reflect.TypeOf(tc.expected), fmt.Sprintf("[%v] %T not the expected %T", tc.onTerm, pb, tc.expected))
 	}

--- a/bib/internal/progress/progress_test.go
+++ b/bib/internal/progress/progress_test.go
@@ -19,7 +19,7 @@ func TestProgressNew(t *testing.T) {
 	}{
 		{"term", &progress.TerminalProgressBar{}, ""},
 		{"debug", &progress.DebugProgressBar{}, ""},
-		{"plain", &progress.PlainProgressBar{}, ""},
+		{"verbose", &progress.VerboseProgressBar{}, ""},
 		// unknown progress type
 		{"bad", nil, `unknown progress type: "bad"`},
 	} {
@@ -33,13 +33,13 @@ func TestProgressNew(t *testing.T) {
 	}
 }
 
-func TestPlainProgress(t *testing.T) {
+func TestVerboseProgress(t *testing.T) {
 	var buf bytes.Buffer
 	restore := progress.MockOsStderr(&buf)
 	defer restore()
 
-	// plain progress never generates progress output
-	pbar, err := progress.NewPlainProgressBar()
+	// verbose progress never generates progress output
+	pbar, err := progress.NewVerboseProgressBar()
 	assert.NoError(t, err)
 	err = pbar.SetProgress(0, "set-progress", 1, 100)
 	assert.NoError(t, err)
@@ -117,7 +117,7 @@ func TestProgressNewAutoselect(t *testing.T) {
 		onTerm   bool
 		expected interface{}
 	}{
-		{false, &progress.PlainProgressBar{}},
+		{false, &progress.VerboseProgressBar{}},
 		{true, &progress.TerminalProgressBar{}},
 	} {
 		restore := progress.MockIsattyIsTerminal(func(uintptr) bool {


### PR DESCRIPTION
This PR adds some missing documentation around the new `--progress` switch. This hopefully helps with the questions/uncertainty raised in e.g. https://github.com/osbuild/bootc-image-builder/pull/765