### PR TITLE
bib: use plain squashfs for the ISO rootfs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install test dependencies
       run: |
         sudo apt update
-        sudo apt install -y python3-pytest python3-paramiko python3-boto3 flake8 pylint libosinfo-bin
+        sudo apt install -y python3-pytest python3-paramiko python3-boto3 flake8 pylint libosinfo-bin squashfs-tools
     - name: Diskspace (before)
       run: |
         df -h

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -518,7 +518,8 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	default:
 		return nil, fmt.Errorf("unsupported architecture %v", c.Architecture)
 	}
-
+	// see https://github.com/osbuild/bootc-image-builder/issues/733
+	img.RootfsType = manifest.SquashfsRootfs
 	img.Filename = "install.iso"
 
 	mf := manifest.New()

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/mattn/go-isatty v0.0.20
-	github.com/osbuild/images v0.107.0
+	github.com/osbuild/images v0.108.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -225,8 +225,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/osbuild/images v0.107.0 h1:lSH4Wkizm+7ZSzo0xYGs4vNpjmV8JaYZg6GczK/dCfo=
-github.com/osbuild/images v0.107.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
+github.com/osbuild/images v0.108.0 h1:I6Ol6KsbsvCfJnipKKuGnt4todY2NvNt742Bx7y+f+Y=
+github.com/osbuild/images v0.108.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -58,7 +58,7 @@ def test_iso_manifest_smoke(build_container, tc):
     ])
     manifest = json.loads(output)
     # just some basic validation
-    expected_pipeline_names = ["build", "anaconda-tree", "rootfs-image", "efiboot-tree", "bootiso-tree", "bootiso"]
+    expected_pipeline_names = ["build", "anaconda-tree", "efiboot-tree", "bootiso-tree", "bootiso"]
     assert manifest["version"] == "2"
     assert [pipeline["name"] for pipeline in manifest["pipelines"]] == expected_pipeline_names
 


### PR DESCRIPTION
This commit moves to the new "flat" squashfs rootfs image
that is now available in the `images` library (c.f.
https://github.com/osbuild/images/pull/1105).

This will ensures we are no longer using the previous "ext4"
intermediate image that gave problems for big rootfses.

Closes: https://github.com/osbuild/bootc-image-builder/issues/733
