### PR TITLE
build-sys: Bump to Fedora 41

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:40 AS builder
+FROM registry.fedoraproject.org/fedora:41 AS builder
 RUN dnf install -y git-core golang gpgme-devel libassuan-devel && mkdir -p /build/bib
 COPY bib/go.mod bib/go.sum /build/bib/
 ARG GOPROXY=https://proxy.golang.org,direct
@@ -10,7 +10,7 @@ COPY . /build
 WORKDIR /build
 RUN ./build.sh
 
-FROM registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:41
 # Fast-track osbuild so we don't depend on the "slow" Fedora release process to implement new features in bib
 COPY ./group_osbuild-osbuild-fedora.repo /etc/yum.repos.d/
 COPY ./package-requires.txt .


### PR DESCRIPTION
Fedora N-1 (40 now) is stable, but will eventually get stale. In my case we happen to be using this image as a "builder" image and I added a new feature to rpm-ostree, which I didn't ship to F40. I may still do so.

However it's clearly a good idea for us to keep updated.

This all said, it's actually not clear to me that Fedora is the right default base image - it may make sense to target e.g. c10s or c9s?

This all relates to https://gitlab.com/fedora/bootc/tracker/-/issues/2 as well.