### PR TITLE
test: run stuff in parallel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
         # TODO: figure out what exactly podman needs
         # TODO2: figure out how much wecan run in parallel before running
         # out of diskspace
-        sudo -E XDG_RUNTIME_DIR= pytest-3 --basetemp=/mnt/var/tmp/bib-tests -n 4 --dist worksteal --maxschedchunk=1
+        sudo -E XDG_RUNTIME_DIR= pytest-3 --basetemp=/mnt/var/tmp/bib-tests -n 8 --dist worksteal --maxschedchunk=1
     - name: Diskspace (after)
       if: ${{ always() }}
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
         # TODO: figure out what exactly podman needs
         # TODO2: figure out how much wecan run in parallel before running
         # out of diskspace
-        sudo -E XDG_RUNTIME_DIR= pytest-3 --basetemp=/mnt/var/tmp/bib-tests -n 8 --dist worksteal --maxschedchunk=1
+        sudo -E XDG_RUNTIME_DIR= pytest-3 --basetemp=/mnt/var/tmp/bib-tests -n 2 --dist worksteal --maxschedchunk=1
     - name: Diskspace (after)
       if: ${{ always() }}
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,7 +130,9 @@ jobs:
         # podman needs (parts of) the environment but will break when
         # XDG_RUNTIME_DIR is set.
         # TODO: figure out what exactly podman needs
-        sudo -E XDG_RUNTIME_DIR= pytest-3 --basetemp=/mnt/var/tmp/bib-tests
+        # TODO2: figure out how much wecan run in parallel before running
+        # out of diskspace
+        sudo -E XDG_RUNTIME_DIR= pytest-3 --basetemp=/mnt/var/tmp/bib-tests -n 4 --dist worksteal --maxschedchunk=1
     - name: Diskspace (after)
       if: ${{ always() }}
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,6 +108,13 @@ jobs:
         sudo -E pip install --user -r test/requirements.txt
     - name: Workarounds for GH runner diskspace
       run: |
+        # move swap to the root disk
+        ls -lh /mnt/swapfile
+        sudo swapoff -a
+        sudo rm -f /mnt/swapfile
+        sudo dd if=/dev/zero of=/swapfile bs=1M count=4096
+        sudo mkswap /swapfile
+        sudo swapon /swapfile
         # use custom basetemp here because /var/tmp is on a smaller disk
         # than /mnt
         sudo mkdir -p /mnt/var/tmp/bib-tests

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,3 +20,10 @@ def pytest_make_parametrize_id(config, val):  # pylint: disable=W0613
     if isinstance(val, TestCase):
         return f"{val}"
     return None
+
+
+@pytest.fixture(name="shared_tmpdir", scope='session')
+def shared_tmpdir_fixture(tmp_path_factory):
+    tmp_path = tmp_path_factory.getbasetemp().parent / "shared"
+    tmp_path.mkdir(exist_ok=True)
+    yield tmp_path

--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -58,7 +58,7 @@ def build_fake_container_fixture(shared_tmpdir, build_container):
     tmp_path = shared_tmpdir / "build-fake-container"
 
     container_tag = "bootc-image-builder-test-faked-osbuild"
-    with FileLock(tmp_path + ".lock"):
+    with FileLock(shared_tmpdir / pathlib.Path(container_tag + ".lock")):
         if tmp_path.exists():
             return container_tag
         tmp_path.mkdir()

--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -57,6 +57,7 @@ def build_fake_container_fixture(shared_tmpdir, build_container):
     """Build a container with a fake osbuild and returns the name"""
     tmp_path = shared_tmpdir / "build-fake-container"
 
+    container_tag = "bootc-image-builder-test-faked-osbuild"
     with FileLock(tmp_path + ".lock"):
         if tmp_path.exists():
             return container_tag
@@ -99,7 +100,6 @@ def build_fake_container_fixture(shared_tmpdir, build_container):
         RUN chmod 755 /usr/bin/podman
         """), encoding="utf8")
 
-        container_tag = "bootc-image-builder-test-faked-osbuild"
         subprocess.check_call([
             "podman", "build",
             "-t", container_tag,

--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import platform
 import random
 import string
@@ -7,6 +8,7 @@ import textwrap
 from contextlib import contextmanager
 
 import pytest
+from filelock import FileLock
 
 
 @contextmanager
@@ -33,67 +35,74 @@ def make_container(container_path, arch=None):
 
 
 @pytest.fixture(name="build_container", scope="session")
-def build_container_fixture():
+def build_container_fixture(shared_tmpdir):
     """Build a container from the Containerfile and returns the name"""
     if tag_from_env := os.getenv("BIB_TEST_BUILD_CONTAINER_TAG"):
         return tag_from_env
 
     container_tag = "bootc-image-builder-test"
-    subprocess.check_call([
-        "podman", "build",
-        "-f", "Containerfile",
-        "-t", container_tag,
-    ])
+    with FileLock(shared_tmpdir / pathlib.Path(container_tag + ".lock")):
+        if not os.path.exists(shared_tmpdir / container_tag):
+            subprocess.check_call([
+                "podman", "build",
+                "-f", "Containerfile",
+                "-t", container_tag,
+            ])
+            (shared_tmpdir / container_tag).write_text("done")
     return container_tag
 
 
 @pytest.fixture(name="build_fake_container", scope="session")
-def build_fake_container_fixture(tmpdir_factory, build_container):
+def build_fake_container_fixture(shared_tmpdir, build_container):
     """Build a container with a fake osbuild and returns the name"""
-    tmp_path = tmpdir_factory.mktemp("build-fake-container")
+    tmp_path = shared_tmpdir / "build-fake-container"
 
-    # see https://github.com/osbuild/osbuild/blob/main/osbuild/testutil/__init__.py#L91
-    tracing_podman_path = tmp_path / "tracing-podman"
-    tracing_podman_path.write_text(textwrap.dedent("""\
-    #!/bin/sh -e
+    with FileLock(tmp_path + ".lock"):
+        if tmp_path.exists():
+            return container_tag
+        tmp_path.mkdir()
+        # see https://github.com/osbuild/osbuild/blob/main/osbuild/testutil/__init__.py#L91
+        tracing_podman_path = tmp_path / "tracing-podman"
+        tracing_podman_path.write_text(textwrap.dedent("""\
+        #!/bin/sh -e
 
-    TRACE_PATH=/output/"$(basename $0)".log
-    for arg in "$@"; do
-        echo "$arg" >> "$TRACE_PATH"
-    done
-    # extra separator to differenciate between calls
-    echo >> "$TRACE_PATH"
-    exec "$0".real "$@"
-    """), encoding="utf8")
+        TRACE_PATH=/output/"$(basename $0)".log
+        for arg in "$@"; do
+            echo "$arg" >> "$TRACE_PATH"
+        done
+        # extra separator to differenciate between calls
+        echo >> "$TRACE_PATH"
+        exec "$0".real "$@"
+        """), encoding="utf8")
 
-    fake_osbuild_path = tmp_path / "fake-osbuild"
-    fake_osbuild_path.write_text(textwrap.dedent("""\
-    #!/bin/bash -e
+        fake_osbuild_path = tmp_path / "fake-osbuild"
+        fake_osbuild_path.write_text(textwrap.dedent("""\
+        #!/bin/bash -e
 
-    # injest generated manifest from the images library, if we do not
-    # do this images may fail with "broken" pipe errors
-    cat - >/dev/null
+        # injest generated manifest from the images library, if we do not
+        # do this images may fail with "broken" pipe errors
+        cat - >/dev/null
 
-    mkdir -p /output/qcow2
-    echo "fake-disk.qcow2" > /output/qcow2/disk.qcow2
+        mkdir -p /output/qcow2
+        echo "fake-disk.qcow2" > /output/qcow2/disk.qcow2
 
-    """), encoding="utf8")
+        """), encoding="utf8")
 
-    cntf_path = tmp_path / "Containerfile"
+        cntf_path = tmp_path / "Containerfile"
 
-    cntf_path.write_text(textwrap.dedent(f"""\n
-    FROM {build_container}
-    COPY fake-osbuild /usr/bin/osbuild
-    RUN chmod 755 /usr/bin/osbuild
-    COPY --from={build_container} /usr/bin/podman /usr/bin/podman.real
-    COPY tracing-podman /usr/bin/podman
-    RUN chmod 755 /usr/bin/podman
-    """), encoding="utf8")
+        cntf_path.write_text(textwrap.dedent(f"""\n
+        FROM {build_container}
+        COPY fake-osbuild /usr/bin/osbuild
+        RUN chmod 755 /usr/bin/osbuild
+        COPY --from={build_container} /usr/bin/podman /usr/bin/podman.real
+        COPY tracing-podman /usr/bin/podman
+        RUN chmod 755 /usr/bin/podman
+        """), encoding="utf8")
 
-    container_tag = "bootc-image-builder-test-faked-osbuild"
-    subprocess.check_call([
-        "podman", "build",
-        "-t", container_tag,
-        tmp_path,
-    ])
-    return container_tag
+        container_tag = "bootc-image-builder-test-faked-osbuild"
+        subprocess.check_call([
+            "podman", "build",
+            "-t", container_tag,
+            tmp_path,
+        ])
+        return container_tag

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -4,3 +4,5 @@ paramiko==2.12.0
 boto3==1.33.13
 qmp==1.1.0
 pylint==3.2.5
+pytest-xdist==3.6.1
+filelock==3.16.1

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -392,6 +392,10 @@ def build_images(shared_tmpdir, build_container, tc, force_aws_upload, gpg_conf,
         target_arch_args = []
         if tc.target_arch:
             target_arch_args = ["--target-arch", tc.target_arch]
+        else:
+            # enforce target arch as we also pull the aarch64 version
+            # in here and podman will reuse aarch64 without the explicit arch
+            target_arch_args = ["--target-arch", platform.machine()]
 
         with tempfile.TemporaryDirectory() as tempdir:
             if "ami" in image_types:


### PR DESCRIPTION
Use filelock.FileLock to workaround the issue that session fixtures do not work with xdist. This should probably be redone in some less hard to read way :(

[edit: results so far not too encouraging, also for some reason the most important function to parallize is build_images() but that for some reason (pytest scopes side-effects?) is only run in sequence even though it it supposed to be parrallel with e.g. "sudo pytest   -s -n 8  ./test/test_build.py::test_iso_installs"]
[edit2: I (strongly) suspect the issue is the indirect paramerization of the fixtures, it seems those cannot be parallelized by xdist so we need to rework/remove the fixtures which is probably a good idea anyway as they got a bit out of hand here]

Results:
- sequencial: 1h47min (pr#791)
- with -n4: 1h8m (but failure in between: no space left on device :(
- with -n8: 50min (but download failures in the iso so not full comparable and no space left on device)

(just for reference: on my machine with a moderate network connection /var/tmp/bib-tests takes 54G and a -n 16 run takes 38min, the runners have 66G on /mnt and require around 10G of /var/lib/containers storage)