### PR TITLE
README: Clarify optional SELinux dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ podman machine start
 
 ## ✍ Prerequisites
 
-The package `osbuild-selinux` or equivalent osbuild SELinux policies must be installed in the system running
+If you are on a system with SELinux enforced: The package `osbuild-selinux` or equivalent osbuild SELinux policies must be installed in the system running
 `bootc-image-builder`.
 
 ## 🚀 Examples


### PR DESCRIPTION
SELinux may not be enforced, e.g. as is the case on Debian.

Ported over from https://github.com/osbuild/osbuild.github.io/pull/138

Please note that I'm not the original author of this suggestion, I merely wanted to help @egodigitus by re-opening the change in the correct place.