### PR TITLE
main: add --verbose,-v persistent flag that increases  verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Flags:
       --progress string        type of progress bar to use (e.g. verbose, term)
       --type string            image type to build [qcow2, ami] (default "qcow2")
       --target-arch string     architecture to build image for (default is the native architecture)
+
+Global Flags:
+  -v, --verbose            Switch to verbose mode
 ```
 
 ### Detailed description of optional flags
@@ -143,6 +146,7 @@ Flags:
 | **--tls-verify**  | Require HTTPS and verify certificates when contacting registries                                          |    `true`     |
 | **--type**        | [Image type](#-image-types) to build                                                                      |    `qcow2`    |
 | **--target-arch** | [Target arch](#-target-architecture) to build                                                             |       ❌      |
+| **--verbose**     | Switch output/progress to verbose mode    |   `false`   |
 
 The `--type` parameter can be given multiple times and multiple outputs will
 be produced.

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -148,7 +148,7 @@ def test_bib_errors_only_once(tmp_path, container_storage, build_fake_container)
     assert res.stderr.count(needle) == 1
 
 
-@pytest.mark.parametrize("version_argument", ["version", "--version", "-v"])
+@pytest.mark.parametrize("version_argument", ["version", "--version"])
 def test_bib_version(tmp_path, container_storage, build_fake_container, version_argument):
     output_path = tmp_path / "output"
     output_path.mkdir(exist_ok=True)

--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -169,8 +169,11 @@ def test_bib_version(tmp_path, container_storage, build_fake_container, version_
         capture_output=True, text=True, check=False)
     if git_res.returncode == 0:
         expected_rev = git_res.stdout.strip()
-    needle = f"revision: {expected_rev}"
-    assert needle in res.stdout
+    assert f"build_revision: {expected_rev}" in res.stdout
+    assert "build_time: " in res.stdout
+    assert "build_tainted: " in res.stdout
+    # we have a final newline
+    assert res.stdout[-1] == "\n"
 
 
 def test_bib_no_outside_container_warning_in_container(tmp_path, container_storage, build_fake_container):


### PR DESCRIPTION
This commit adds `--verbose,-v` which will increase the verbosity
of logrus and also switch the --progress to "verbose". This is
addressing the feedback we got in
https://github.com/osbuild/bootc-image-builder/pull/765
and a followup for #776

The new `-v` clashes unfortunately with cobras default for version,
so there is no single dash flag for version anymore. Most unix tools
(e.g. cp,rsync,mv,curl,ssh,tar) use "-v" for "--verbose" so IMHO we
should follow suite. Unfortuantely there is no consistency in linux,
e.g. git,gcc are counter examples where it means version). I would
still go with -v for verbose as ssh,tar,curl are probably used
more often to get verbose output.

---

main,test: tweak cmdVersion

This commit tweak the new and very nice functionality of cmdVersion (see commit message for details)

---

(note that the above commit is not strictly needed, because of the slightly inflexible way of how cobra handles the version I had to look at this function and did some quick tweaks but I could drop it from this PR and/or drop it entirely)

Thanks to Ondrej for the suggestion about -v/--verbose