### PR TITLE
test: make diskusage data available even after successful runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,3 +136,4 @@ jobs:
       run: |
         df -h
         sudo du -sh * /var/tmp /tmp /var/lib/containers | sort -sh
+        sudo find /mnt/var/tmp/bib-tests -name du.log|sudo xargs cat


### PR DESCRIPTION
Pytest eats the output for successful tests so in order to know how often cached images need to get removed we need a trick like this.