### PR TITLE
plan: give testingfarm more time to complete

### DIFF
--- a/plans/integration.fmf
+++ b/plans/integration.fmf
@@ -32,7 +32,7 @@ execute:
     pip install --user -r test/requirements.txt
     echo "Run tests"
     pytest --force-aws-upload
-  duration: 3h
+  duration: 4h
 finish:
   how: shell
   script: df -h


### PR DESCRIPTION
We recently hit the issue that bootc-image-builder is no longer releasing. It turns out we hit the limit of our integration tests. Increase this limit for now.