### PR TITLE
progress: tweak progress error reporting

### DIFF
--- a/bib/pkg/progress/export_test.go
+++ b/bib/pkg/progress/export_test.go
@@ -25,3 +25,11 @@ func MockIsattyIsTerminal(fn func(uintptr) bool) (restore func()) {
 		isattyIsTerminal = saved
 	}
 }
+
+func MockOsbuildCmd(s string) (restore func()) {
+	saved := osbuildCmd
+	osbuildCmd = s
+	return func() {
+		osbuildCmd = saved
+	}
+}

--- a/bib/pkg/progress/progress.go
+++ b/bib/pkg/progress/progress.go
@@ -368,10 +368,12 @@ func runOSBuildWithProgress(pb ProgressBar, manifest []byte, store, outputDirect
 	}
 	wp.Close()
 
+	var statusErrs []error
 	for {
 		st, err := osbuildStatus.Status()
 		if err != nil {
-			return fmt.Errorf("error reading osbuild status: %w", err)
+			statusErrs = append(statusErrs, err)
+			continue
 		}
 		if st == nil {
 			break
@@ -391,6 +393,9 @@ func runOSBuildWithProgress(pb ProgressBar, manifest []byte, store, outputDirect
 
 	if err := cmd.Wait(); err != nil {
 		return fmt.Errorf("error running osbuild: %w\nOutput:\n%s", err, stdio.String())
+	}
+	if len(statusErrs) > 0 {
+		return fmt.Errorf("errors parsing osbuild status:\n%w", errors.Join(statusErrs...))
 	}
 
 	return nil


### PR DESCRIPTION
This commit adds catpure of os.Std{out,err} when running osbuild so that we capture the error log and can display it as part of an error from osbuild, e.g. when osbuild itself crashes.

This gives us more accurate error reporting if anything fails during the osbuild building.

[edit: this will also help https://github.com/osbuild/image-builder-cli/pull/21]