### PR TITLE
test: use `librepo` for `centos-9` too

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -60,6 +60,7 @@ class TestCaseC9S(TestCase):
     container_ref: str = os.getenv(
         "BIB_TEST_BOOTC_CONTAINER_TAG",
         "quay.io/centos-bootc/centos-bootc:stream9")
+    use_librepo: bool = True
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
This commit switches centos-9 to use librepo as well. This is a bit sad because it means we have no repo anymore that uses the default "curl" backend. But even the centos9 mirrors are now so unreliable that we cannot get things merged.

We should switch the default downloader here to librepo but we need some downstream test that ensures that subscribed content can still be installed with librepo (it should work but there is no explicit test in our testsuite).

(failing test, e.g. https://github.com/osbuild/bootc-image-builder/actions/runs/13134326900/job/36704112622?pr=818, re-run three times now)