### PR TITLE
distrodef: fix incorrect detection of `centos-10` vs `10.0`

### DIFF
--- a/bib/internal/distrodef/distrodef.go
+++ b/bib/internal/distrodef/distrodef.go
@@ -51,7 +51,7 @@ func findDistroDef(defDirs []string, distro, wantedVerStr string) (string, error
 			if err != nil {
 				return "", fmt.Errorf("cannot parse distro version from %q: %w", m, err)
 			}
-			if wantedVer.Compare(haveVer) > 0 && haveVer.Compare(bestFuzzyVer) > 0 {
+			if wantedVer.Compare(haveVer) >= 0 && haveVer.Compare(bestFuzzyVer) > 0 {
 				bestFuzzyVer = haveVer
 				bestFuzzyMatch = m
 			}

--- a/bib/internal/distrodef/distrodef_test.go
+++ b/bib/internal/distrodef/distrodef_test.go
@@ -108,6 +108,16 @@ func TestFindDistroDefMultiFuzzyMinorReleases(t *testing.T) {
 	assert.True(t, strings.HasSuffix(def, "b/b/centos-9.10.yaml"), def)
 }
 
+func TestFindDistroDefMultiFuzzyMinorReleasesIsZero(t *testing.T) {
+	defDirs := makeFakeDistrodefRoot(t, []string{
+		"a/centos-9.yaml",
+		"a/centos-10.yaml",
+	})
+	def, err := findDistroDef(defDirs, "centos", "10.0")
+	assert.NoError(t, err)
+	assert.True(t, strings.HasSuffix(def, "a/centos-10.yaml"), def)
+}
+
 func TestFindDistroDefMultiFuzzyError(t *testing.T) {
 	defDirs := makeFakeDistrodefRoot(t, []string{
 		"a/fedora-40.yaml",


### PR DESCRIPTION
This commit fixes the issue that when the `os-release` has an
`ID=10.0` in it, a distrodef file ending with `-10` will not
be identified as the closest match because the code is using
a "strictly bigger" relation to sort versions but for semver
`10.0` and `10` are just identical so we need ">=" instead
of ">" (see the actual diff).

We saw this issue with the `rhel-10.0` beta that has a
`VERSION_ID=10.0` field and a `rhel-10.yaml` distro-def. Here the
code was skipping over rhel-10.yaml and felt back to rhel-9 when
it really should have used `rhel-10.yaml`.

Thanks to Achilleas for tracking this down.
