### PR TITLE
many: deal with incorrect status from osbuild better

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -405,6 +405,8 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload, gpg_
             "-v", "/var/tmp/osbuild-test-store:/store",  # share the cache between builds
             "-v", "/var/lib/containers/storage:/var/lib/containers/storage",  # mount the host's containers storage
         ]
+        if tc.podman_terminal:
+            cmd.append("-t")
 
         if tc.sign:
             sign_container_image(gpg_conf, registry_conf, tc.container_ref)

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -27,6 +27,8 @@ class TestCase:
     disk_config: str = ""
     # use librepo for the downloading
     use_librepo: bool = False
+    # podman_terminal enables the podman -t option to get progress
+    podman_terminal: bool = False
 
     def bib_rootfs_args(self):
         if self.rootfs:
@@ -61,6 +63,7 @@ class TestCaseC9S(TestCase):
         "BIB_TEST_BOOTC_CONTAINER_TAG",
         "quay.io/centos-bootc/centos-bootc:stream9")
     use_librepo: bool = True
+    use_terminal: bool = True
 
 
 @dataclasses.dataclass

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -202,6 +202,8 @@ podman_run_common = [
     "--privileged",
     "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
     "--security-opt", "label=type:unconfined_t",
+    # ensure we run in reasonable memory limits
+    "--memory=8g", "--memory-swap=8g",
 ]
 
 


### PR DESCRIPTION
go.mod: upadate to latest `images` to get PR#1200

This commit updates the images library to pull in the fix [0] for
the overly long messages from osbuild. This should test the
(previously) failing test that runs the centos-9 ISO with an
attached terminal.

[0] https://github.com/osbuild/images/pull/1200

---

test: run the centos-9 test with an attached terminal

This commit changes the centos-9 test to run with `podman -t` so
that we have a test-case that uses the `terminal` progress. This
is prompted by:
a) we have no integration test currently that uses the terminal
   progress for the full build
b) a konflux failure/memory leak that showed because there the
   test is run with `-t`

----

This commit ensures that we do restrict the memory of the bib
test conatiner to catch excessive memory usage. This is prompted
by a memory leak when dealing with unrecoverable status messages
that lead to failures in konflux.

---

This commit changes the progress parser (again) to deal with
errors from the osbuild json progress scanner. On errors we
will now exit right away and potentially kill osbuild but
provide an error message that hints how to workaround the
issue.

The original code assumed we get transient errors like json
decode issues. However it turns out that this is not always
the case, some errors from a bufio.Scanner are unrecoverable
(like ErrTooBig) and trying again just leads to an endless
loop. We can also not "break" wait for the build to finish
because that would appear like the progress is broken
forever and we would still have to report an error (just
much later).
