### PR TITLE
github/workflows/tests: fix linter by adapting versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,12 @@ on:
   # for merge queue
   merge_group:
 
+env:
+  GO_VERSION: 1.22
+  # see https://golangci-lint.run/product/changelog
+  # to select a version that supports the GO_VERSION given above
+  GOLANGCI_LINT_VERSION: v1.59.1
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -20,10 +26,10 @@ jobs:
     name: "⌨ Lint & unittests"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Check out code into the Go module directory
@@ -41,7 +47,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout 5m0s
           working-directory: bib
 


### PR DESCRIPTION
For some reason the linter fails but also the golang version should be consistent with `go.mod`