### PR TITLE
main: switch to librepo by default

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -656,7 +656,7 @@ func buildCobraCmdline() (*cobra.Command, error) {
 		return nil, fmt.Errorf("cannot hide 'local' :%w", err)
 	}
 	manifestCmd.Flags().String("rootfs", "", "Root filesystem type. If not given, the default configured in the source container image is used.")
-	manifestCmd.Flags().Bool("use-librepo", false, "(experimenal) switch to librepo for pkg download, needs new enough osbuild")
+	manifestCmd.Flags().Bool("use-librepo", true, "switch to librepo for pkg download, needs new enough osbuild")
 	// --config is only useful for developers who run bib outside
 	// of a container to generate a manifest. so hide it by
 	// default from users.


### PR DESCRIPTION
[draft as I want to double check with QE first that we have good coverage for subscribed content testing in the downstream tests]

When building the anaconda-iso from centos or fedora there is a high chance to hit a bad mirror. The libcurl method is not able to fallback to different mirrors so the user experience is bad. Switch to librepo by default therefore.

Closes: https://github.com/osbuild/bootc-image-builder/issues/835
