### PR TITLE
bib: add support for file/directory customizations

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -22,6 +22,7 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/pathpolicy"
 	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/policies"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
 	"github.com/sirupsen/logrus"
@@ -379,6 +380,27 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 		return nil, err
 	}
 	img.PartitionTable = pt
+
+	// Check Directory/File Customizations are valid
+	dc := customizations.GetDirectories()
+	fc := customizations.GetFiles()
+	if err := blueprint.ValidateDirFileCustomizations(dc, fc); err != nil {
+		return nil, err
+	}
+	if err := blueprint.CheckDirectoryCustomizationsPolicy(dc, policies.OstreeCustomDirectoriesPolicies); err != nil {
+		return nil, err
+	}
+	if err := blueprint.CheckFileCustomizationsPolicy(fc, policies.OstreeCustomFilesPolicies); err != nil {
+		return nil, err
+	}
+	img.Files, err = blueprint.FileCustomizationsToFsNodeFiles(fc)
+	if err != nil {
+		return nil, err
+	}
+	img.Directories, err = blueprint.DirectoryCustomizationsToFsNodeDirectories(dc)
+	if err != nil {
+		return nil, err
+	}
 
 	// For the bootc-disk image, the filename is the basename and the extension
 	// is added automatically for each disk format

--- a/bib/cmd/bootc-image-builder/main_test.go
+++ b/bib/cmd/bootc-image-builder/main_test.go
@@ -196,6 +196,23 @@ func TestManifestGenerationUserConfig(t *testing.T) {
 	}
 }
 
+// Disk images require a container for the build/image pipelines
+var containerSpec = container.Spec{
+	Source:  "test-container",
+	Digest:  "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+	ImageID: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+}
+
+// diskContainers can be passed to Serialize() to get a minimal disk image
+var diskContainers = map[string][]container.Spec{
+	"build": {
+		containerSpec,
+	},
+	"image": {
+		containerSpec,
+	},
+}
+
 // TODO: this tests at this layer is not ideal, it has too much knowledge
 // over the implementation details of the "images" library and how an
 // image.NewBootcDiskImage() works (i.e. what the pipeline names are and
@@ -208,23 +225,8 @@ func TestManifestSerialization(t *testing.T) {
 	// Tests that the manifest is generated without error and is serialized
 	// with expected key stages.
 
-	// Disk images require a container for the build/image pipelines
-	containerSpec := container.Spec{
-		Source:  "test-container",
-		Digest:  "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-		ImageID: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
-	}
-	diskContainers := map[string][]container.Spec{
-		"build": {
-			containerSpec,
-		},
-		"image": {
-			containerSpec,
-		},
-	}
-
 	// ISOs require a container for the bootiso-tree, build packages, and packages for the anaconda-tree (with a kernel).
-	isoContainers := map[string][]container.Spec{
+	var isoContainers = map[string][]container.Spec{
 		"bootiso-tree": {
 			containerSpec,
 		},

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.6
 	github.com/hashicorp/go-version v1.7.0
 	github.com/mattn/go-isatty v0.0.20
-	github.com/osbuild/images v0.120.0
+	github.com/osbuild/images v0.121.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -232,8 +232,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/osbuild/images v0.120.0 h1:6zXCp59AG03qajZlg/GJ07Fr4E6z5qaZshOuWgAse7g=
-github.com/osbuild/images v0.120.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
+github.com/osbuild/images v0.121.0 h1:urGJ1/RqSmJQ7tq4YPtc3phCI3EJP/i4epHkD50LlCQ=
+github.com/osbuild/images v0.121.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -358,6 +358,17 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload, gpg_
             "kernel": {
                 "append": kargs,
             },
+            "files": [
+                {
+                    "path": "/etc/some-file",
+                    "data": "some-data",
+                },
+            ],
+            "directories": [
+                {
+                    "path": "/etc/some-dir",
+                },
+            ],
         },
     }
     testutil.maybe_create_filesystem_customizations(cfg, tc)
@@ -528,6 +539,14 @@ def test_image_boots(image_type):
             assert_disk_customizations(image_type, test_vm)
         else:
             assert_fs_customizations(image_type, test_vm)
+
+        # check file/dir customizations
+        exit_status, output = test_vm.run("stat /etc/some-file", user=image_type.username, password=image_type.password)
+        assert exit_status == 0
+        assert "File: /etc/some-file" in output
+        _, output = test_vm.run("stat /etc/some-dir", user=image_type.username, password=image_type.password)
+        assert exit_status == 0
+        assert "File: /etc/some-dir" in output
 
 
 @pytest.mark.parametrize("image_type", gen_testcases("ami-boot"), indirect=["image_type"])

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -779,3 +779,46 @@ def test_iso_manifest_use_librepo(build_container, use_librepo):
         assert "org.osbuild.librepo" in manifest["sources"]
     else:
         assert "org.osbuild.curl" in manifest["sources"]
+
+
+def test_manifest_customization_custom_file_smoke(tmp_path, build_container):
+    # no need to parameterize this test, toml is the same for all containers
+    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
+
+    cfg = {
+        "blueprint": {
+            "customizations": {
+                "files": [
+                    {
+                        "path": "/etc/custom_file",
+                        "data": "hello world"
+                    },
+                ],
+                "directories": [
+                    {
+                        "path": "/etc/custom_dir",
+                    },
+                ],
+            },
+        },
+    }
+
+    output_path = tmp_path / "output"
+    output_path.mkdir(exist_ok=True)
+    config_json_path = output_path / "config.json"
+    config_json_path.write_text(json.dumps(cfg), encoding="utf-8")
+
+    output = subprocess.check_output([
+        *testutil.podman_run_common,
+        "-v", f"{output_path}:/output",
+        build_container,
+        "manifest", f"{container_ref}",
+        "--config", "/output/config.json",
+    ], stderr=subprocess.PIPE, encoding="utf8")
+    json.loads(output)
+    assert '"to":"tree:///etc/custom_file"' in output
+    assert ('{"type":"org.osbuild.mkdir","options":{"paths":'
+            '[{"path":"/etc/custom_dir","exist_ok":true}]},'
+            '"devices":{"disk":{"type":"org.osbuild.loopback"'
+            ',"options":{"filename":"disk.raw"') in output


### PR DESCRIPTION
This commit adds support for files/directories in blueprint
customizations.

This needs https://github.com/osbuild/images/pull/1227

Closes: https://github.com/osbuild/bootc-image-builder/issues/834

[edit this will also need an update in https://osbuild.org/docs/user-guide/blueprint-reference/#files-and-directories once merged]