### PR TITLE
Drop JAVA_COMMUNITY_DEPENDENCIES

### DIFF
--- a/.tekton/bootc-image-builder-pull-request.yaml
+++ b/.tekton/bootc-image-builder-pull-request.yaml
@@ -134,9 +134,6 @@ spec:
       - description: ""
         name: CHAINS-GIT_COMMIT
         value: $(tasks.clone-repository-amd64.results.commit)
-      - description: ""
-        name: JAVA_COMMUNITY_DEPENDENCIES
-        value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
       - name: init
         params:

--- a/.tekton/bootc-image-builder-push.yaml
+++ b/.tekton/bootc-image-builder-push.yaml
@@ -131,9 +131,6 @@ spec:
       - description: ""
         name: CHAINS-GIT_COMMIT
         value: $(tasks.clone-repository-amd64.results.commit)
-      - description: ""
-        name: JAVA_COMMUNITY_DEPENDENCIES
-        value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
       - name: init
         params:


### PR DESCRIPTION
This change solve the konflux build failure in https://github.com/osbuild/bootc-image-builder/pull/767 which is a prerequisite for builash task migration, see https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-remote-oci-ta/0.3/MIGRATION.md. We did the same for the downstream bib pipeline.