### PR TITLE
Enable strict toml checks again

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -3,7 +3,7 @@ module github.com/osbuild/bootc-image-builder/bib
 go 1.22.8
 
 require (
-	github.com/BurntSushi/toml v1.4.0
+	github.com/BurntSushi/toml v1.5.0
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/hashicorp/go-version v1.7.0
 	github.com/mattn/go-isatty v0.0.20

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -8,6 +8,8 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.12.9 h1:2zJy5KA+l0loz1HzEGqyNnjd3fyZA31ZBCGKacp6lLg=

--- a/bib/internal/buildconfig/config.go
+++ b/bib/internal/buildconfig/config.go
@@ -59,9 +59,13 @@ func decodeTomlBuildConfig(r io.Reader, what string) (*BuildConfig, error) {
 	dec := toml.NewDecoder(r)
 
 	var conf BuildConfig
-	_, err := dec.Decode(&conf)
+	metadata, err := dec.Decode(&conf)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode %q: %w", what, err)
+	}
+
+	if len(metadata.Undecoded()) > 0 {
+		return nil, fmt.Errorf("cannot decode %q: unknown keys found: %v", what, metadata.Undecoded())
 	}
 
 	return &conf, nil

--- a/bib/internal/buildconfig/config_test.go
+++ b/bib/internal/buildconfig/config_test.go
@@ -134,6 +134,16 @@ func TestReadLegacyJSONConfig(t *testing.T) {
 	assert.Equal(t, expectedBuildConfig, cfg)
 }
 
+func TestTomlUnknownKeysError(t *testing.T) {
+	fakeUserCnfPath := makeFakeConfig(t, "config.toml", `
+[[birds]]
+name = "toucan"
+`)
+	_, err := buildconfig.ReadWithFallback(fakeUserCnfPath)
+
+	assert.ErrorContains(t, err, "unknown keys found: [birds birds.name]")
+}
+
 func TestJsonUnknownKeysError(t *testing.T) {
 	fakeUserCnfPath := makeFakeConfig(t, "config.json", `
 {


### PR DESCRIPTION
This PR enables https://github.com/osbuild/bootc-image-builder/pull/549 again. 

With the new version of burntSushi/toml we have a fix for https://github.com/burntSushi/toml/issues/425 so we can enable strict checking again.