### PR TITLE
Reapply "buildconfig: disable tests for undecoded keys for now"

### DIFF
--- a/bib/internal/buildconfig/config.go
+++ b/bib/internal/buildconfig/config.go
@@ -59,13 +59,9 @@ func decodeTomlBuildConfig(r io.Reader, what string) (*BuildConfig, error) {
 	dec := toml.NewDecoder(r)
 
 	var conf BuildConfig
-	metadata, err := dec.Decode(&conf)
+	_, err := dec.Decode(&conf)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode %q: %w", what, err)
-	}
-
-	if len(metadata.Undecoded()) > 0 {
-		return nil, fmt.Errorf("cannot decode %q: unknown keys found: %v", what, metadata.Undecoded())
 	}
 
 	return &conf, nil

--- a/bib/internal/buildconfig/config_test.go
+++ b/bib/internal/buildconfig/config_test.go
@@ -134,16 +134,6 @@ func TestReadLegacyJSONConfig(t *testing.T) {
 	assert.Equal(t, expectedBuildConfig, cfg)
 }
 
-func TestTomlUnknownKeysError(t *testing.T) {
-	fakeUserCnfPath := makeFakeConfig(t, "config.toml", `
-[[birds]]
-name = "toucan"
-`)
-	_, err := buildconfig.ReadWithFallback(fakeUserCnfPath)
-
-	assert.ErrorContains(t, err, "unknown keys found: [birds birds.name]")
-}
-
 func TestJsonUnknownKeysError(t *testing.T) {
 	fakeUserCnfPath := makeFakeConfig(t, "config.json", `
 {


### PR DESCRIPTION
This reverts commit c4c3470691d84300aa5fabf948964a6f40e05eda.

This causes issue because we lack toml keys for "Type"