### PR TITLE
bib: add experimental flag `debug-qemu-user`

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/osbuild/images/pkg/cloud/awscloud"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/dnfjson"
+	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -462,6 +463,9 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		osbuildEnv = append(osbuildEnv, envVars...)
 	}
 
+	if experimentalflags.Bool("debug-qemu-user") {
+		osbuildEnv = append(osbuildEnv, "OBSBUILD_EXPERIMENAL=debug-qemu-user")
+	}
 	osbuildOpts := progress.OSBuildOptions{
 		StoreDir:  osbuildStore,
 		OutputDir: outputDir,


### PR DESCRIPTION
This commit adds support for more debug for `qemu-user` options. When settings:
```
$ sudo IMAGE_BUILDER_EXPERIMENAL=debug-qemu-user bootc-image-builder ...
```
extra debug from qemu-user will be printed.

This hopefully helps to track down the root cause of https://github.com/podman-desktop/extension-bootc/issues/1475