### PR TITLE
Revert "build(deps): bump golangci/golangci-lint-action from 6 to 7"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout 5m0s


### PR DESCRIPTION
This reverts commit 1c3d2dab0dae47e2c50bba2fcfa9da9d5d592d8a to fix CI.
golangci-lint-action v7 needs golangci v2.
Changing from v1 to v2 needs more changes than this and will be done separately.
see https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#compatibility