### PR TITLE
Update golangci lint "ignore version"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ env:
   GO_VERSION: 1.22
   # see https://golangci-lint.run/product/changelog
   # to select a version that supports the GO_VERSION given above
-  GOLANGCI_LINT_VERSION: v1.59.1
+  GOLANGCI_LINT_VERSION: v2.0.2
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,6 @@ on:
 
 env:
   GO_VERSION: 1.22
-  # see https://golangci-lint.run/product/changelog
-  # to select a version that supports the GO_VERSION given above
-  GOLANGCI_LINT_VERSION: v2.0.2
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -44,10 +41,14 @@ jobs:
       - name: Install libgpgme devel package
         run: sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev
 
+      - name: Extract golangci-lint version from Makefile
+        id: golangci_lint_version
+        run: echo "GOLANGCI_LINT_VERSION=$(awk -F '=' '/^GOLANGCI_LINT_VERSION *=/{print $2}' Makefile)" >> "$GITHUB_OUTPUT"
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          version: ${{ steps.golangci_lint_version.outputs.GOLANGCI_LINT_VERSION }}
           args: --timeout 5m0s
           working-directory: bib
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 .PHONY: all
 all: build-binary build-container
 
+GOLANGCI_LINT_VERSION=v2.0.2
+GO_BINARY?=go
+
+# the fallback '|| echo "golangci-lint' really expects this file
+# NOT to exist! This is just a trigger to help installing golangci-lint
+GOLANGCI_LINT_BIN=$(shell which golangci-lint 2>/dev/null || echo "golangci-lint")
+
 .PHONY: help
 help:
 	@echo 'Usage:'
@@ -45,3 +52,14 @@ push-check: build-binary build-container test  ## run all checks and tests befor
 	    exit 1; \
 	fi
 	@echo "All looks good - congratulations"
+
+$(GOLANGCI_LINT_BIN):
+	@echo "golangci-lint does not seem to be installed"
+	@read -p "Press <ENTER> to install it or <CTRL>-c to abort"
+	$(GO_BINARY) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) || \
+	( echo "if the go version is a problem, you can set GO_BINARY e.g. GO_BINARY=go.1.23.8 \
+	      after installing it e.g. go install golang.org/dl/go1.23.8@latest" ; exit 1 )
+
+.PHONY: lint
+lint: $(GOLANGCI_LINT_BIN)  ## run the linters to check for bad code
+	cd bib && $(GOLANGCI_LINT_BIN) run

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ clean:  ## clean all build and test artifacts
 
 .PHONY: test
 test:  ## run all tests - Be aware that the tests take a really long time
+	cd bib && go test -race ./...
 	@echo "Be aware that the tests take a really long time"
 	@echo "Running tests as root"
 	sudo -E pip install --user -r test/requirements.txt

--- a/bib/cmd/bootc-image-builder/cloud.go
+++ b/bib/cmd/bootc-image-builder/cloud.go
@@ -29,6 +29,7 @@ func upload(uploader cloud.Uploader, path string, flags *pflag.FlagSet) error {
 	if err != nil {
 		return fmt.Errorf("cannot upload: %v", err)
 	}
+	// nolint:errcheck
 	defer file.Close()
 
 	var r io.Reader = file

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -126,7 +126,7 @@ func checkMountpoints(filesystems []blueprint.FilesystemCustomization, policy *p
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("The following errors occurred while validating custom mountpoints:\n%w", errors.Join(errs...))
+		return fmt.Errorf("the following errors occurred while validating custom mountpoints:\n%w", errors.Join(errs...))
 	}
 	return nil
 }

--- a/bib/cmd/bootc-image-builder/image_test.go
+++ b/bib/cmd/bootc-image-builder/image_test.go
@@ -108,7 +108,7 @@ func TestCheckFilesystemCustomizationsValidates(t *testing.T) {
 				{Mountpoint: "/ostree"},
 			},
 			ptmode:      disk.RawPartitioningMode,
-			expectedErr: "The following errors occurred while validating custom mountpoints:\npath \"/ostree\" is not allowed",
+			expectedErr: "the following errors occurred while validating custom mountpoints:\npath \"/ostree\" is not allowed",
 		},
 		{
 			fsCust: []blueprint.FilesystemCustomization{
@@ -116,7 +116,7 @@ func TestCheckFilesystemCustomizationsValidates(t *testing.T) {
 				{Mountpoint: "/var"},
 			},
 			ptmode:      disk.RawPartitioningMode,
-			expectedErr: "The following errors occurred while validating custom mountpoints:\npath \"/var\" is not allowed",
+			expectedErr: "the following errors occurred while validating custom mountpoints:\npath \"/var\" is not allowed",
 		},
 		{
 			fsCust: []blueprint.FilesystemCustomization{
@@ -124,7 +124,7 @@ func TestCheckFilesystemCustomizationsValidates(t *testing.T) {
 				{Mountpoint: "/var/data"},
 			},
 			ptmode:      disk.BtrfsPartitioningMode,
-			expectedErr: "The following errors occurred while validating custom mountpoints:\npath \"/var/data\" is not allowed",
+			expectedErr: "the following errors occurred while validating custom mountpoints:\npath \"/var/data\" is not allowed",
 		},
 		{
 			fsCust: []blueprint.FilesystemCustomization{
@@ -132,7 +132,7 @@ func TestCheckFilesystemCustomizationsValidates(t *testing.T) {
 				{Mountpoint: "/boot/"},
 			},
 			ptmode:      disk.BtrfsPartitioningMode,
-			expectedErr: "The following errors occurred while validating custom mountpoints:\npath \"/boot/\" must be canonical",
+			expectedErr: "the following errors occurred while validating custom mountpoints:\npath \"/boot/\" must be canonical",
 		},
 		{
 			fsCust: []blueprint.FilesystemCustomization{
@@ -141,7 +141,7 @@ func TestCheckFilesystemCustomizationsValidates(t *testing.T) {
 				{Mountpoint: "/opt"},
 			},
 			ptmode:      disk.BtrfsPartitioningMode,
-			expectedErr: "The following errors occurred while validating custom mountpoints:\npath \"/boot/\" must be canonical\npath \"/opt\" is not allowed",
+			expectedErr: "the following errors occurred while validating custom mountpoints:\npath \"/boot/\" must be canonical\npath \"/opt\" is not allowed",
 		},
 	} {
 		if tc.expectedErr == "" {

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -166,7 +167,7 @@ func makeManifest(c *ManifestConfig, solver *dnfjson.Solver, cacheRoot string) (
 	return mf, depsolvedRepos, nil
 }
 
-func saveManifest(ms manifest.OSBuildManifest, fpath string) error {
+func saveManifest(ms manifest.OSBuildManifest, fpath string) (err error) {
 	b, err := json.MarshalIndent(ms, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal data for %q: %s", fpath, err.Error())
@@ -176,8 +177,7 @@ func saveManifest(ms manifest.OSBuildManifest, fpath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create output file %q: %s", fpath, err.Error())
 	}
-	// nolint:errcheck
-	defer fp.Close()
+	defer func() { err = errors.Join(err, fp.Close()) }()
 	if _, err := fp.Write(b); err != nil {
 		return fmt.Errorf("failed to write output file %q: %s", fpath, err.Error())
 	}

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -176,6 +176,7 @@ func saveManifest(ms manifest.OSBuildManifest, fpath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create output file %q: %s", fpath, err.Error())
 	}
+	// nolint:errcheck
 	defer fp.Close()
 	if _, err := fp.Write(b); err != nil {
 		return fmt.Errorf("failed to write output file %q: %s", fpath, err.Error())

--- a/bib/cmd/upload/main.go
+++ b/bib/cmd/upload/main.go
@@ -40,6 +40,7 @@ func uploadAMI(cmd *cobra.Command, args []string) {
 
 	f, err := os.Open(filename)
 	check(err)
+	// nolint:errcheck
 	defer f.Close()
 
 	check(uploader.UploadAndRegister(f, os.Stderr))

--- a/bib/internal/buildconfig/config.go
+++ b/bib/internal/buildconfig/config.go
@@ -87,6 +87,7 @@ func loadConfig(path string) (*externalBlueprint.Blueprint, error) {
 		if err != nil {
 			return nil, err
 		}
+		// nolint:errcheck
 		defer fp.Close()
 	}
 

--- a/bib/internal/buildconfig/config_test.go
+++ b/bib/internal/buildconfig/config_test.go
@@ -184,6 +184,7 @@ func TestReadWithFallbackFromStdin(t *testing.T) {
 	fakeUserCnfPath := makeFakeConfig(t, "fake-stdin", fakeConfigJSON)
 	fakeStdinFp, err := os.Open(fakeUserCnfPath)
 	require.NoError(t, err)
+	// nolint:errcheck
 	defer fakeStdinFp.Close()
 
 	restore := buildconfig.MockOsStdin(fakeStdinFp)

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -304,7 +304,7 @@ def test_mount_ostree_error(tmpdir_factory, build_container):
             "manifest", f"{container_ref}",
             "--config", "/output/config.json",
         ], stderr=subprocess.PIPE, encoding="utf8")
-    assert 'The following errors occurred while validating custom mountpoints:\npath "/ostree" is not allowed' \
+    assert 'the following errors occurred while validating custom mountpoints:\npath "/ostree" is not allowed' \
         in exc.value.stderr
 
 


### PR DESCRIPTION
This is the alternative implementation to #891 (and #890 )
Which ignores the defer file.Close() remarks of the linter.
Only for the file where we write to we return an error message, similar message as we do _while_ writing.