### PR TITLE
image: set `UseRHELLoraxTemplates` only on rhel/centos/eln

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/big"
 	"math/rand"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -435,6 +436,10 @@ func labelForISO(os *source.OSRelease, arch *arch.Arch) string {
 	}
 }
 
+func needsRHELLoraxTemplates(si source.OSRelease) bool {
+	return si.ID == "rhel" || slices.Contains(si.IDLike, "rhel") || si.VersionID == "eln"
+}
+
 func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, error) {
 	if c.Imgref == "" {
 		return nil, fmt.Errorf("pipeline: no base image defined")
@@ -498,9 +503,7 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	img.Kickstart.OSTree = &kickstart.OSTree{
 		OSName: "default",
 	}
-	// use lorax-templates-rhel if the source distro is not Fedora with the exception of Fedora ELN
-	img.UseRHELLoraxTemplates =
-		c.SourceInfo.OSRelease.ID != "fedora" || c.SourceInfo.OSRelease.VersionID == "eln"
+	img.UseRHELLoraxTemplates = needsRHELLoraxTemplates(c.SourceInfo.OSRelease)
 
 	switch c.Architecture {
 	case arch.ARCH_X86_64:

--- a/bib/internal/source/source.go
+++ b/bib/internal/source/source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -16,6 +17,7 @@ type OSRelease struct {
 	VersionID  string
 	Name       string
 	VariantID  string
+	IDLike     []string
 }
 
 type Info struct {
@@ -69,6 +71,10 @@ func LoadInfo(root string) (*Info, error) {
 	if err != nil {
 		logrus.Debugf("cannot read UEFI vendor: %v, setting it to none", err)
 	}
+	var idLike []string
+	if osrelease["ID_LIKE"] != "" {
+		idLike = strings.Split(osrelease["ID_LIKE"], " ")
+	}
 
 	return &Info{
 		OSRelease: OSRelease{
@@ -77,6 +83,7 @@ func LoadInfo(root string) (*Info, error) {
 			Name:       osrelease["NAME"],
 			PlatformID: osrelease["PLATFORM_ID"],
 			VariantID:  osrelease["VARIANT_ID"],
+			IDLike:     idLike,
 		},
 
 		UEFIVendor: vendor,


### PR DESCRIPTION
This commit flips the detection if we need the rhel lorax template. It will only use it when it detect running on rhel/centos/eln. This should help with the common case of distros that need the generic lorax template but do not set the name to fedora.

This might help with the immediate issue in https://github.com/osbuild/bootc-image-builder/issues/904 but is probably useful on its own (as the generic lorax template is the (more) common case).