### PR TITLE
test: enable `osinfo_for()` centos10

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -634,11 +634,7 @@ def osinfo_for(it: ImageBuildResult, arch: str) -> str:
     if it.container_ref.endswith("/centos-bootc/centos-bootc:stream9"):
         return f"{base} 'CentOS Stream 9 ({arch})'\n"
     if it.container_ref.endswith("/centos-bootc/centos-bootc:stream10"):
-        # XXX: uncomment once
-        # https://gitlab.com/libosinfo/osinfo-db/-/commit/fc811ba5a792967e22a0108de5a245b23da3cc66
-        # gets released
-        # return f"CentOS Stream 10 ({arch})"
-        return ""
+        return f"Media is an installer for OS 'CentOS Stream 10 ({arch})'\n"
     if "/fedora/fedora-bootc:" in it.container_ref:
         ver = it.container_ref.rsplit(":", maxsplit=1)[1]
         return f"{base} 'Fedora Server {ver} ({arch})'\n"


### PR DESCRIPTION
This commit enables testing for centos10 based installer images.

The fix https://gitlab.com/libosinfo/osinfo-db/-/commit/fc811ba5a792967e22a0108de5a245b23da3cc66 is now released.