### PR TITLE
workflow: run pytests via matrix to get more parallel runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,10 +70,30 @@ jobs:
         # allow seemingly unreachable commands
         SHELLCHECK_OPTS: -e SC1091 -e SC2002 -e SC2317
 
+  collect_tests:
+    runs-on: ubuntu-latest
+    outputs:
+      test_files: ${{ steps.collect.outputs.test_files }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Collect test files
+        id: collect
+        run: |
+          TEST_FILES=$(ls test/test_*.py | sort)
+          JSON_FILES=$(echo "${TEST_FILES}" | jq -R | jq -cs )
+          echo "test_files=${JSON_FILES}" >> $GITHUB_OUTPUT
+
   integration:
     # TODO: run this also via tmt/testing-farm
     name: "Integration"
     runs-on: ubuntu-24.04
+    needs: collect_tests
+    strategy:
+      matrix:
+        test_file: ${{ fromJson(needs.collect_tests.outputs.test_files) }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -136,7 +156,7 @@ jobs:
         # podman needs (parts of) the environment but will break when
         # XDG_RUNTIME_DIR is set.
         # TODO: figure out what exactly podman needs
-        sudo -E XDG_RUNTIME_DIR= pytest-3 --basetemp=/mnt/var/tmp/bib-tests
+        sudo -E XDG_RUNTIME_DIR= pytest-3 --basetemp=/mnt/var/tmp/bib-tests ${{ matrix.test_file }}
     - name: Diskspace (after)
       if: ${{ always() }}
       run: |

--- a/test/test_build_disk.py
+++ b/test/test_build_disk.py
@@ -610,53 +610,6 @@ def test_image_build_without_se_linux_denials(image_type):
         f"denials in log {image_type.journal_output}"
 
 
-@pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
-@pytest.mark.parametrize("image_type", gen_testcases("anaconda-iso"), indirect=["image_type"])
-def test_iso_installs(image_type):
-    installer_iso_path = image_type.img_path
-    test_disk_path = installer_iso_path.with_name("test-disk.img")
-    with open(test_disk_path, "w", encoding="utf8") as fp:
-        fp.truncate(10_1000_1000_1000)
-    # install to test disk
-    with QEMU(test_disk_path, cdrom=installer_iso_path) as vm:
-        vm.start(wait_event="qmp:RESET", snapshot=False, use_ovmf=True)
-        vm.force_stop()
-    # boot test disk and do extremly simple check
-    with QEMU(test_disk_path) as vm:
-        vm.start(use_ovmf=True)
-        exit_status, _ = vm.run("true", user=image_type.username, password=image_type.password)
-        assert exit_status == 0
-        assert_kernel_args(vm, image_type)
-
-
-def osinfo_for(it: ImageBuildResult, arch: str) -> str:
-    base = "Media is an installer for OS"
-    if it.container_ref.endswith("/centos-bootc/centos-bootc:stream9"):
-        return f"{base} 'CentOS Stream 9 ({arch})'\n"
-    if it.container_ref.endswith("/centos-bootc/centos-bootc:stream10"):
-        return f"Media is an installer for OS 'CentOS Stream 10 ({arch})'\n"
-    if "/fedora/fedora-bootc:" in it.container_ref:
-        ver = it.container_ref.rsplit(":", maxsplit=1)[1]
-        return f"{base} 'Fedora Server {ver} ({arch})'\n"
-    raise ValueError(f"unknown osinfo string for '{it.container_ref}'")
-
-
-@pytest.mark.skipif(platform.system() != "Linux", reason="osinfo detect test only runs on linux right now")
-@pytest.mark.parametrize("image_type", gen_testcases("anaconda-iso"), indirect=["image_type"])
-def test_iso_os_detection(image_type):
-    installer_iso_path = image_type.img_path
-    arch = image_type.img_arch
-    if not arch:
-        arch = platform.machine()
-    result = subprocess.run([
-        "osinfo-detect",
-        installer_iso_path,
-    ], capture_output=True, text=True, check=True)
-    osinfo_output = result.stdout
-    expected_output = f"Media is bootable.\n{osinfo_for(image_type, arch)}"
-    assert osinfo_output == expected_output
-
-
 @pytest.mark.skipif(platform.system() != "Linux", reason="osinfo detect test only runs on linux right now")
 @pytest.mark.skipif(not testutil.has_executable("unsquashfs"), reason="need unsquashfs")
 @pytest.mark.parametrize("image_type", gen_testcases("anaconda-iso"), indirect=["image_type"])

--- a/test/test_build_iso.py
+++ b/test/test_build_iso.py
@@ -1,0 +1,85 @@
+import os
+import platform
+import subprocess
+from contextlib import ExitStack
+
+import pytest
+# local test utils
+import testutil
+from containerbuild import build_container_fixture    # pylint: disable=unused-import
+from testcases import gen_testcases
+from vm import QEMU
+
+from test_build_disk import (
+    assert_kernel_args,
+    ImageBuildResult,
+)
+from test_build_disk import (  # pylint: disable=unused-import
+    gpg_conf_fixture,
+    image_type_fixture,
+    registry_conf_fixture,
+    shared_tmpdir_fixture,
+)
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
+@pytest.mark.parametrize("image_type", gen_testcases("anaconda-iso"), indirect=["image_type"])
+def test_iso_installs(image_type):
+    installer_iso_path = image_type.img_path
+    test_disk_path = installer_iso_path.with_name("test-disk.img")
+    with open(test_disk_path, "w", encoding="utf8") as fp:
+        fp.truncate(10_1000_1000_1000)
+    # install to test disk
+    with QEMU(test_disk_path, cdrom=installer_iso_path) as vm:
+        vm.start(wait_event="qmp:RESET", snapshot=False, use_ovmf=True)
+        vm.force_stop()
+    # boot test disk and do extremly simple check
+    with QEMU(test_disk_path) as vm:
+        vm.start(use_ovmf=True)
+        exit_status, _ = vm.run("true", user=image_type.username, password=image_type.password)
+        assert exit_status == 0
+        assert_kernel_args(vm, image_type)
+
+
+def osinfo_for(it: ImageBuildResult, arch: str) -> str:
+    base = "Media is an installer for OS"
+    if it.container_ref.endswith("/centos-bootc/centos-bootc:stream9"):
+        return f"{base} 'CentOS Stream 9 ({arch})'\n"
+    if it.container_ref.endswith("/centos-bootc/centos-bootc:stream10"):
+        return f"Media is an installer for OS 'CentOS Stream 10 ({arch})'\n"
+    if "/fedora/fedora-bootc:" in it.container_ref:
+        ver = it.container_ref.rsplit(":", maxsplit=1)[1]
+        return f"{base} 'Fedora Server {ver} ({arch})'\n"
+    raise ValueError(f"unknown osinfo string for '{it.container_ref}'")
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="osinfo detect test only runs on linux right now")
+@pytest.mark.parametrize("image_type", gen_testcases("anaconda-iso"), indirect=["image_type"])
+def test_iso_os_detection(image_type):
+    installer_iso_path = image_type.img_path
+    arch = image_type.img_arch
+    if not arch:
+        arch = platform.machine()
+    result = subprocess.run([
+        "osinfo-detect",
+        installer_iso_path,
+    ], capture_output=True, text=True, check=True)
+    osinfo_output = result.stdout
+    expected_output = f"Media is bootable.\n{osinfo_for(image_type, arch)}"
+    assert osinfo_output == expected_output
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="osinfo detect test only runs on linux right now")
+@pytest.mark.skipif(not testutil.has_executable("unsquashfs"), reason="need unsquashfs")
+@pytest.mark.parametrize("image_type", gen_testcases("anaconda-iso"), indirect=["image_type"])
+def test_iso_install_img_is_squashfs(tmp_path, image_type):
+    installer_iso_path = image_type.img_path
+    with ExitStack() as cm:
+        mount_point = tmp_path / "cdrom"
+        mount_point.mkdir()
+        subprocess.check_call(["mount", installer_iso_path, os.fspath(mount_point)])
+        cm.callback(subprocess.check_call, ["umount", os.fspath(mount_point)])
+        # ensure install.img is the "flat" squashfs, before PR#777 the content
+        # was an intermediate ext4 image "squashfs-root/LiveOS/rootfs.img"
+        output = subprocess.check_output(["unsquashfs", "-ls", mount_point / "images/install.img"], text=True)
+        assert "usr/bin/bootc" in output

--- a/test/test_progress.py
+++ b/test/test_progress.py
@@ -13,6 +13,9 @@ from containerbuild import (
 
 
 def test_progress_debug(tmp_path, build_fake_container):
+    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
+
     output_path = tmp_path / "output"
     output_path.mkdir(exist_ok=True)
 
@@ -21,7 +24,7 @@ def test_progress_debug(tmp_path, build_fake_container):
         build_fake_container,
         "build",
         "--progress=debug",
-        "quay.io/centos-bootc/centos-bootc:stream9",
+        container_ref,
     ]
     res = subprocess.run(cmdline, capture_output=True, check=True, text=True)
     assert res.stderr.count("Start progressbar") == 1


### PR DESCRIPTION
This commit moves the test running into a matrix so that
we get more parallel testing. It will still be (much) dominated
by `test_build_disk.py` but at least this way a flaky test in
e.g. `test_container` is much faster to re-run.

With multiple VMs we can probably also parallelize the tests [1]
because we have less images per VM to test so diskspace
may be less of an issue.

---

test: split test_build.py into test_build_{disk,iso}

Split this big test into smaller files because we
will run the tests in parallel via a dynamic (per-file)
github matrix. This will allow faster tests and easier
re-runs if a single test is flaky only a small subset
will have to be retriggered.


[1] https://github.com/osbuild/bootc-image-builder/pull/787