### PR TITLE
test: split cross-arch test into its own file

### DIFF
--- a/test/test_build_cross.py
+++ b/test/test_build_cross.py
@@ -1,0 +1,23 @@
+import platform
+
+import pytest
+
+from testcases import gen_testcases
+
+from test_build_disk import (  # pylint: disable=unused-import
+    assert_disk_image_boots,
+    build_container_fixture,
+    gpg_conf_fixture,
+    image_type_fixture,
+    registry_conf_fixture,
+    shared_tmpdir_fixture,
+)
+
+
+# This testcase is not part of "test_build_disk.py:test_image_boots"
+# because it takes ~30min on the GH runners so moving it into a
+# separate file ensures it is run in parallel on GH.
+@pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
+@pytest.mark.parametrize("image_type", gen_testcases("qemu-cross"), indirect=["image_type"])
+def test_image_boots_cross(image_type):
+    assert_disk_image_boots(image_type)

--- a/test/test_build_disk.py
+++ b/test/test_build_disk.py
@@ -520,6 +520,10 @@ def assert_kernel_args(test_vm, image_type):
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
 @pytest.mark.parametrize("image_type", gen_testcases("qemu-boot"), indirect=["image_type"])
 def test_image_boots(image_type):
+    assert_disk_image_boots(image_type)
+
+
+def assert_disk_image_boots(image_type):
     with QEMU(image_type.img_path, arch=image_type.img_arch) as test_vm:
         # user/password login works
         exit_status, _ = test_vm.run("true", user=image_type.username, password=image_type.password)

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -100,16 +100,8 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             TestCaseC9S(image="anaconda-iso"),
             TestCaseC10S(image="anaconda-iso"),
         ]
-    if what == "qemu-boot":
-        test_cases = [
-            # test default partitioning
-            TestCaseFedora(image="qcow2"),
-            # test with custom disk configs
-            TestCaseC9S(image="qcow2", disk_config="swap"),
-            TestCaseFedora(image="raw", disk_config="btrfs"),
-            TestCaseC9S(image="raw", disk_config="lvm"),
-        ]
-        # do a cross arch test too
+    if what == "qemu-cross":
+        test_cases = []
         if platform.machine() == "x86_64":
             test_cases.append(
                 TestCaseC9S(image="raw", target_arch="arm64"))
@@ -117,6 +109,15 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             # TODO: add arm64->x86_64 cross build test too
             pass
         return test_cases
+    if what == "qemu-boot":
+        return [
+            # test default partitioning
+            TestCaseFedora(image="qcow2"),
+            # test with custom disk configs
+            TestCaseC9S(image="qcow2", disk_config="swap"),
+            TestCaseFedora(image="raw", disk_config="btrfs"),
+            TestCaseC9S(image="raw", disk_config="lvm"),
+        ]
     if what == "all":
         return [
             klass(image=img)


### PR DESCRIPTION
This commit moves the cross arch build into its own file
so that it ran run in parallel in the GH runners. Its is
a relatively expensive test (~20min on my machine) so
moving it out should save quite a bit of time.
