### PR TITLE
Makefile: bump version of golang-ci to 2.1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all
 all: build-binary build-container
 
-GOLANGCI_LINT_VERSION=v2.0.2
+GOLANGCI_LINT_VERSION=v2.1.6
 GO_BINARY?=go
 
 # the fallback '|| echo "golangci-lint' really expects this file


### PR DESCRIPTION
We currently see errors in bib CI like:
```
Error: Failed to run: Error: requested golangci-lint version 'v2.0.2' isn't supported: we support only v2.1.0 and later versions, Error: requested golangci-lint version 'v2.0.2' isn't supported: we support only v2.1.0 and later versions
```
(c.f. https://github.com/osbuild/bootc-image-builder/actions/runs/14831005614/job/41632016536?pr=906)

So bump the version to fix this.