### PR TITLE
main: drop rootfs cross-arch disable

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -278,18 +278,6 @@ func manifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progress
 				return nil, nil, fmt.Errorf(`no default root filesystem type specified in container, please use "--rootfs" to set manually`)
 			}
 		}
-
-		// TODO: on a cross arch build we need to be conservative, i.e. we can
-		// only use the default ext4 because if xfs is select we run into the
-		// issue that mkfs.xfs calls "ioctl(BLKBSZSET)" which is missing in
-		// qemu-user.
-		// The fix has been merged upstream https://www.mail-archive.com/qemu-devel@nongnu.org/msg1037409.html
-		// and is expected to be included in v9.1.0 https://github.com/qemu/qemu/commit/e6e903db6a5e960e595f9f1fd034adb942dd9508
-		// Remove the following condition once we update to qemu-user v9.1.0.
-		if cntArch != arch.Current() && rootfsType != "ext4" {
-			logrus.Warningf("container preferred root filesystem %q cannot be used during cross arch build", rootfsType)
-			rootfsType = "ext4"
-		}
 	}
 	// Gather some data from the containers distro
 	sourceinfo, err := source.LoadInfo(container.Root())

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -556,8 +556,7 @@ def test_manifest_fs_customizations_xarch(tmp_path, build_container, fscustomiza
         "manifest", f"{container_ref}",
     ])
 
-    # cross-arch builds only support ext4 (for now)
-    assert_fs_customizations(fscustomizations, "ext4", output)
+    assert_fs_customizations(fscustomizations, rootfs, output)
 
 
 def find_grub2_iso_stage_from(manifest_str):


### PR DESCRIPTION
All platforms where `bootc-image-builder` runs that have `qemu-user` available have upgrade to a version >= 9.1.0.