### PR TITLE
test: set the cache-ttl to 1h in our tests

### DIFF
--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -25,6 +25,7 @@ def make_container(container_path, arch=None):
 
     subprocess.check_call([
         "podman", "build",
+        "--cache-ttl=1h",
         "-t", container_tag,
         "--arch", arch,
         container_path], encoding="utf8")
@@ -41,6 +42,7 @@ def build_container_fixture():
     container_tag = "bootc-image-builder-test"
     subprocess.check_call([
         "podman", "build",
+        "--cache-ttl=1h",
         "-f", "Containerfile",
         "-t", container_tag,
     ])


### PR DESCRIPTION
The current caching of the test containers can lead to unexpected results when e.g. the upstream osbuild repo gets updated but podman caches the relevant line in the Containerfile because the install of osbuild has not changed. To counter this the container building sets an agressive TTL of 1h for the cache.

This fixes the issues locally.