### PR TITLE
Extract SELinux policy from container

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -332,8 +332,7 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 	img := image.NewBootcDiskImage(containerSource)
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
-	// TODO: get from the bootc container instead of hardcoding it
-	img.SELinux = "targeted"
+	img.SELinux = c.SourceInfo.SELinuxPolicy
 
 	img.KernelOptionsAppend = []string{
 		"rw",

--- a/bib/internal/source/source.go
+++ b/bib/internal/source/source.go
@@ -1,6 +1,8 @@
 package source
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -21,8 +23,9 @@ type OSRelease struct {
 }
 
 type Info struct {
-	OSRelease  OSRelease
-	UEFIVendor string
+	OSRelease     OSRelease
+	UEFIVendor    string
+	SELinuxPolicy string
 }
 
 func validateOSRelease(osrelease map[string]string) error {
@@ -58,6 +61,36 @@ func uefiVendor(root string) (string, error) {
 	return "", fmt.Errorf("cannot find UEFI vendor in %s", bootupdEfiDir)
 }
 
+func readSelinuxPolicy(root string) (string, error) {
+	configPath := "etc/selinux/config"
+	f, err := os.Open(path.Join(root, configPath))
+	if err != nil {
+		return "", fmt.Errorf("cannot read selinux config %s: %w", configPath, err)
+	}
+	policy := ""
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if len(line) == 0 {
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return "", errors.New("selinux config: invalid input")
+		}
+		key := strings.TrimSpace(parts[0])
+		if key == "SELINUXTYPE" {
+			policy = strings.TrimSpace(parts[1])
+		}
+	}
+
+	return policy, nil
+}
+
 func LoadInfo(root string) (*Info, error) {
 	osrelease, err := distro.ReadOSReleaseFromTree(root)
 	if err != nil {
@@ -71,6 +104,12 @@ func LoadInfo(root string) (*Info, error) {
 	if err != nil {
 		logrus.Debugf("cannot read UEFI vendor: %v, setting it to none", err)
 	}
+
+	selinuxPolicy, err := readSelinuxPolicy(root)
+	if err != nil {
+		logrus.Debugf("cannot read selinux policy: %v, setting it to none", err)
+	}
+
 	var idLike []string
 	if osrelease["ID_LIKE"] != "" {
 		idLike = strings.Split(osrelease["ID_LIKE"], " ")
@@ -86,6 +125,7 @@ func LoadInfo(root string) (*Info, error) {
 			IDLike:     idLike,
 		},
 
-		UEFIVendor: vendor,
+		UEFIVendor:    vendor,
+		SELinuxPolicy: selinuxPolicy,
 	}, nil
 }


### PR DESCRIPTION
Currently we are always hardcoding "targeted", which is not working for the centos automotive sig that use a custom policy.

To completely work, this also needs https://github.com/osbuild/images/pull/1506, otherwise the extracted selinux policy is not used in the build pipeline.