### PR TITLE
image: set ISOBoot to Grub2ISOBoot for x86_64

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -514,6 +514,7 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 			BIOS:       true,
 			UEFIVendor: c.SourceInfo.UEFIVendor,
 		}
+		img.ISOBoot = manifest.Grub2ISOBoot
 	case arch.ARCH_AARCH64:
 		// aarch64 always uses UEFI, so let's enforce the vendor
 		if c.SourceInfo.UEFIVendor == "" {


### PR DESCRIPTION
github.com/osbuild/images v0.124.0 introduced `img.ISOBoot`. This field must be set to either `SyslinuxISOBoot` or `Grub2ISOBoot` for the ISO to boot on BIOS systems.

See: https://github.com/osbuild/images/pull/1289
Closes: https://github.com/osbuild/bootc-image-builder/issues/912