### PR TITLE
Apply disk or filesystem customization from embedded image customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,6 @@ By default, the following modules are enabled for all Anaconda ISOs:
 The `disable` list is processed after the `enable` list and therefore takes priority. In other words, adding the same module in both `enable` and `disable` will result in the module being **disabled**.
 Furthermore, adding a module that is enabled by default to `disable` will result in the module being **disabled**.
 
-
 ## Building
 
 To build the container locally you can run

--- a/README.md
+++ b/README.md
@@ -349,6 +349,12 @@ sudo podman run \
 The configuration can also be passed in via stdin when `--config -`
 is used. Only JSON configuration is supported in this mode.
 
+Additionally, images can embed a build config file, either as
+`config.json` or `config.toml` in the `/usr/lib/bootc-image-builder`
+directory. If this exist, and contains filesystem or disk
+customizations, then these are used by default if no such
+customization are specified in the regular build config.
+
 ### Users (`user`, array)
 
 Possible fields:

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -209,6 +209,18 @@ func genPartitionTable(c *ManifestConfig, customizations *blueprint.Customizatio
 	if err != nil {
 		return nil, fmt.Errorf("error reading disk customizations: %w", err)
 	}
+
+	// Embedded disk customization applies if there was no local customization
+	if fsCust == nil && diskCust == nil && c.SourceInfo != nil && c.SourceInfo.ImageCustomization != nil {
+		imageCustomizations := c.SourceInfo.ImageCustomization
+
+		fsCust = imageCustomizations.GetFilesystems()
+		diskCust, err = imageCustomizations.GetPartitioning()
+		if err != nil {
+			return nil, fmt.Errorf("error reading disk customizations: %w", err)
+		}
+	}
+
 	switch {
 	// XXX: move into images library
 	case fsCust != nil && diskCust != nil:

--- a/bib/internal/buildconfig/config.go
+++ b/bib/internal/buildconfig/config.go
@@ -101,6 +101,16 @@ func loadConfig(path string) (*externalBlueprint.Blueprint, error) {
 	}
 }
 
+func LoadConfig(path string) (*imagesBlueprint.Blueprint, error) {
+	externalBp, err := loadConfig(path)
+	if err != nil {
+		return nil, err
+	}
+
+	bp := externalBlueprint.Convert(*externalBp)
+	return &bp, nil
+}
+
 func readWithFallback(userConfig string) (*externalBlueprint.Blueprint, error) {
 	// user asked for an explicit config
 	if userConfig != "" {

--- a/test/test_build_disk.py
+++ b/test/test_build_disk.py
@@ -137,7 +137,8 @@ def registry_conf_fixture(shared_tmpdir, request):
             "-p", f"{registry_port}:5000",
             "--restart", "always",
             "--name", registry_container_name,
-            "registry:2"
+            # We use a copy of docker.io registry to avoid running into docker.io pull rate limits
+            "ghcr.io/osbuild/bootc-image-builder/registry:2"
         ], check=True)
 
     registry_container_state = subprocess.run([


### PR DESCRIPTION
This allows bootc images to embed a  file in `/usr/lib/bootc-image-builder` in the image called `config.json` or `config.toml`, which specify more detailed requirements for the  partitioning. From this (which is in the full blueprint format) we extract (only) the disk and/or filesystem customization part.

This is useful to either add extra partitions (like a separate /var), or to override details of the normal partitions (like uuids, labels, etc).

This is discussed in https://github.com/bootc-dev/bootc/issues/926

I used the entire blueprint format so that we can reuse existing docs, and so that we can later use more customization fields if needed.

Note: This (mostly trivially) conflicts with https://github.com/osbuild/bootc-image-builder/pull/928
