### PR TITLE
test: disable `fedora-43` bootc test for now

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -115,7 +115,9 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             TestCaseFedora(image="qcow2"),
             # test with custom disk configs
             TestCaseC9S(image="qcow2", disk_config="swap"),
-            TestCaseFedora43(image="raw", disk_config="btrfs"),
+            # mvo: disabled 2025-05-21 because:
+            # "ERROR Installing to filesystem: Creating ostree deployment: invalid reference format"
+            # TestCaseFedora43(image="raw", disk_config="btrfs"),
             TestCaseC9S(image="raw", disk_config="lvm"),
         ]
     if what == "all":


### PR DESCRIPTION
This commit disabled the `TestCaseFedora43` fow now because it fails in CI with:
```
...
org.osbuild.bootc.install-to-filesystem: 19bb778fae4541936924e98952fc101eabf7f1782856dd0447ae1fef4ad3ac61 {
  "kernel-args": [
    "rw",
    "console=tty0",
    "console=ttyS0",
    "systemd.journald.forward_to_console=1"
  ],
  "target-imgref": "quay.io/fedora/fedora-bootc:43"
}
device/disk (org.osbuild.loopback): loop0 acquired (locked: False)
mount/- (org.osbuild.btrfs): mounting /dev/loop0p4 -> /store/tmp/buildroot-tmp-e004ml_u/mounts/
mount/boot (org.osbuild.xfs): mounting /dev/loop0p3 -> /store/tmp/buildroot-tmp-e004ml_u/mounts/boot
mount/boot-efi (org.osbuild.fat): mounting /dev/loop0p2 -> /store/tmp/buildroot-tmp-e004ml_u/mounts/boot/efi
Mount transient overlayfs for /etc/containers
Creating bind mount for run/osbuild/containers
Installing image: docker://quay.io/fedora/fedora-bootc:43
Initializing ostree layout
ERROR Installing to filesystem: Creating ostree deployment: invalid reference format
```
Until this is resolved this test (against the current in development fedora) is not useful and blocks our CI.