### PR TITLE
Make installed rootfs configurable for when generating an ISO

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -329,7 +329,7 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 		customizations = c.Config.Customizations
 	}
 
-	img := image.NewBootcDiskImage(containerSource)
+	img := image.NewBootcDiskImage(containerSource, containerSource)
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 	// TODO: get from the bootc container instead of hardcoding it

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -547,6 +547,8 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	img.RootfsType = manifest.SquashfsRootfs
 	img.Filename = "install.iso"
 
+	img.InstallRootfsType = c.RootFSType
+
 	mf := manifest.New()
 
 	foundDistro, foundRunner, err := getDistroAndRunner(c.SourceInfo.OSRelease)

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -216,7 +216,12 @@ func manifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progress
 		}
 	}
 
-	if targetArch != "" && arch.FromString(targetArch) != arch.Current() {
+	resolvedArch, err := arch.FromString(targetArch)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if targetArch != "" && resolvedArch != arch.Current() {
 		// TODO: detect if binfmt_misc for target arch is
 		// available, e.g. by mounting the binfmt_misc fs into
 		// the container and inspects the files or by
@@ -226,7 +231,10 @@ func manifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progress
 		if slices.Contains(imgTypes, "iso") {
 			return nil, nil, fmt.Errorf("cannot build iso for different target arches yet")
 		}
-		cntArch = arch.FromString(targetArch)
+		cntArch, err = arch.FromString(targetArch)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 	// TODO: add "target-variant", see https://github.com/osbuild/bootc-image-builder/pull/139/files#r1467591868
 

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -274,19 +274,18 @@ func manifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progress
 	}()
 
 	var rootfsType string
-	if !imageTypes.BuildsISO() {
-		if rootFs != "" {
-			rootfsType = rootFs
-		} else {
-			rootfsType, err = container.DefaultRootfsType()
-			if err != nil {
-				return nil, nil, fmt.Errorf("cannot get rootfs type for container: %w", err)
-			}
-			if rootfsType == "" {
-				return nil, nil, fmt.Errorf(`no default root filesystem type specified in container, please use "--rootfs" to set manually`)
-			}
+	if rootFs != "" {
+		rootfsType = rootFs
+	} else {
+		rootfsType, err = container.DefaultRootfsType()
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot get rootfs type for container: %w", err)
+		}
+		if rootfsType == "" {
+			return nil, nil, fmt.Errorf(`no default root filesystem type specified in container, please use "--rootfs" to set manually`)
 		}
 	}
+
 	// Gather some data from the containers distro
 	sourceinfo, err := source.LoadInfo(container.Root())
 	if err != nil {

--- a/bib/data/defs/fedora-42.yaml
+++ b/bib/data/defs/fedora-42.yaml
@@ -1,0 +1,1 @@
+fedora-40.yaml


### PR DESCRIPTION
Resolves: https://github.com/osbuild/bootc-image-builder/issues/924
Builds off of: https://github.com/osbuild/images/pull/1555

When generating ISOs we ignore the value passed in via `--rootfs`. This PR addresses that.