### PR TITLE
Clarify we build disk images

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -468,7 +468,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot save manifest: %w", err)
 	}
 
-	pbar.SetPulseMsgf("Image building step")
+	pbar.SetPulseMsgf("Disk image building step")
 	pbar.SetMessagef("Building %s", manifest_fname)
 
 	var osbuildEnv []string

--- a/test/test_progress.py
+++ b/test/test_progress.py
@@ -29,7 +29,7 @@ def test_progress_debug(tmp_path, build_fake_container):
     res = subprocess.run(cmdline, capture_output=True, check=True, text=True)
     assert res.stderr.count("Start progressbar") == 1
     assert res.stderr.count("Manifest generation step") == 1
-    assert res.stderr.count("Image building step") == 1
+    assert res.stderr.count("Disk image building step") == 1
     assert res.stderr.count("Build complete") == 1
     assert res.stderr.count("Stop progressbar") == 1
     assert res.stdout.strip() == ""


### PR DESCRIPTION
I almost always stop people who say "image" without qualification because disk images are very different from container images. There's a lingering confusion that bootc-image-builder builds bootc images, which is not true...