### PR TITLE
test: re-enable Fedora43 test

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -115,9 +115,7 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             TestCaseFedora(image="qcow2"),
             # test with custom disk configs
             TestCaseC9S(image="qcow2", disk_config="swap"),
-            # mvo: disabled 2025-05-21 because:
-            # "ERROR Installing to filesystem: Creating ostree deployment: invalid reference format"
-            # TestCaseFedora43(image="raw", disk_config="btrfs"),
+            TestCaseFedora43(image="raw", disk_config="btrfs"),
             TestCaseC9S(image="raw", disk_config="lvm"),
         ]
     if what == "all":


### PR DESCRIPTION
The bootc fedora43 install was failing but with:
https://github.com/bootc-dev/bootc/pull/1337
this should now be fixed (thanks Colin!).

Closes: https://github.com/osbuild/bootc-image-builder/issues/934