### PR TITLE
bib: tweak architecture setting in tests

### DIFF
--- a/bib/cmd/bootc-image-builder/image_test.go
+++ b/bib/cmd/bootc-image-builder/image_test.go
@@ -375,9 +375,8 @@ func findMountableSizeableFor(pt *disk.PartitionTable, needle string) (disk.Moun
 func TestGenPartitionTableSetsRootfsForAllFilesystemsXFS(t *testing.T) {
 	rng := bib.CreateRand()
 
-	a, _ := arch.FromString("amd64")
 	cnf := &bib.ManifestConfig{
-		Architecture: a,
+		Architecture: arch.ARCH_X86_64,
 		RootFSType:   "xfs",
 	}
 	cus := &blueprint.Customizations{
@@ -407,9 +406,8 @@ func TestGenPartitionTableSetsRootfsForAllFilesystemsXFS(t *testing.T) {
 func TestGenPartitionTableSetsRootfsForAllFilesystemsBtrfs(t *testing.T) {
 	rng := bib.CreateRand()
 
-	a, _ := arch.FromString("amd64")
 	cnf := &bib.ManifestConfig{
-		Architecture: a,
+		Architecture: arch.ARCH_X86_64,
 		RootFSType:   "btrfs",
 	}
 	cus := &blueprint.Customizations{}
@@ -431,9 +429,8 @@ func TestGenPartitionTableSetsRootfsForAllFilesystemsBtrfs(t *testing.T) {
 func TestGenPartitionTableDiskCustomizationRunsValidateLayoutConstraints(t *testing.T) {
 	rng := bib.CreateRand()
 
-	a, _ := arch.FromString("amd64")
 	cnf := &bib.ManifestConfig{
-		Architecture: a,
+		Architecture: arch.ARCH_X86_64,
 		RootFSType:   "xfs",
 	}
 	cus := &blueprint.Customizations{
@@ -653,9 +650,8 @@ func TestGenPartitionTableDiskCustomizationSizes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			a, _ := arch.FromString("amd64")
 			cnf := &bib.ManifestConfig{
-				Architecture:  a,
+				Architecture:  arch.ARCH_X86_64,
 				RootFSType:    "xfs",
 				RootfsMinsize: tc.rootfsMinSize,
 			}


### PR DESCRIPTION
Tiny tweak for how we set the architecture in ManifestConfig, not really necessary but avoids a extra/call an extra line.