### PR TITLE
Add initial support for RISC-V architecture

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -412,7 +412,15 @@ func manifestForDiskImage(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest
 			},
 			BIOS: true,
 		}
+	case arch.ARCH_RISCV64:
+		img.Platform = &platform.RISCV64{
+			UEFIVendor: "fedora",
+			BasePlatform: platform.BasePlatform{
+				QCOW2Compat: "1.1",
+			},
+		}
 	}
+	
 
 	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
 		img.KernelOptionsAppend = append(img.KernelOptionsAppend, kopts.Append)
@@ -581,6 +589,13 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 			BasePlatform: platform.BasePlatform{
 				ImageFormat: platform.FORMAT_ISO,
 			},
+		}
+	case arch.ARCH_RISCV64:
+		img.Platform = &platform.RISCV64{
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_ISO,
+			},
+			UEFIVendor: c.SourceInfo.UEFIVendor,
 		}
 	default:
 		return nil, fmt.Errorf("unsupported architecture %v", c.Architecture)

--- a/bib/cmd/bootc-image-builder/partition_tables.go
+++ b/bib/cmd/bootc-image-builder/partition_tables.go
@@ -127,4 +127,13 @@ var partitionTables = distro.BasePartitionTableMap{
 			rootPartition,
 		},
 	},
+	arch.ARCH_RISCV64.String(): disk.PartitionTable{
+		UUID: diskUuidOfUnknownOrigin,
+		Type: disk.PT_GPT,
+		Partitions: []disk.Partition{
+			efiPartition,
+			bootPartition,
+			rootPartition,
+		},
+	},
 }


### PR DESCRIPTION
## Testing
### Native Builds (Successful)
The build is successful with the following command on riscv64 physical machine (Note: Since riscv64 is not an officially supported architecture in Fedora, `Containerfile` changes to use a community-maintained base image: `docker.io/fedorariscv/base:42`. In the future, when fedora is officially supported soon, it can use `registry.fedoraproject.org/fedora:42` directly. More details can be found in the following commit: [link](https://github.com/imguoguo/bootc-image-builder/commit/9376bacc34145dde0a1e15a5f98ec23f83b85304)):

```
podman run \
    --rm \
    -it \
    --privileged \
    --pull=newer \
    --security-opt label=type:unconfined_t \
    -v $(pwd)/output:/output \
    -v /var/lib/containers/storage:/var/lib/containers/storage \
    docker.io/fedorariscv/bootc-image-builder:latest \
    --local \
    --rootfs ext4 \
    --progress verbose \
    --type qcow2 \
    --target-arch riscv64 \
    docker.io/fedorariscv/bootc:42
```

### `bootupctl` Limitations
Currently, bootupctl cannot be used for the installation. Although rust-bootupd has merged riscv64 support in its codebase, a new version has not been tagged and released. This results in the following error:

```
> bootupctl backend install --write-uuid --device /dev/loop0 /run/osbuild/mounts
No components available for this platform.
```

A manual workaround is required: manually place `grubriscv64.efi` and `grub.cfg` in `/boot/efi/EFI/fedora` directory, place `startup.nsh` with content `FS0:\EFI\Fedora\grubriscv64.efi` in `/boot/efi` directory and another `grub.cfg` in `/boot` directory to make the image bootable.

### Validation on RISC-V Hardware
A bootable bootc image was successfully created on a riscv64 physical machine. It can be launched using QEMU after installing the necessary packages (dnf install -y edk2-riscv64 qemu-system-riscv).

QEMU Launch Command:

```
qemu-system-riscv64 -M virt,pflash0=pflash0,acpi=off \
    -m 6G -smp 4 \
    -nographic \
    -blockdev node-name=pflash0,read-only=on,driver=qcow2,file.driver=file,file.filename=/usr/share/edk2/riscv/RISCV_VIRT_CODE.qcow2 \
    -device virtio-net-device,netdev=usernet \
    -netdev user,id=usernet \
    -drive file=Fedora-Minimal-bootc-42-20250617000000.riscv64.QEMU.Generic.qcow2,id=hd0 -device virtio-blk-device,drive=hd0
```
For easy debugging, the default account and password is `root` / `riscv`.

Image Download Link: [Fedora-Minimal-bootc-42-20250617000000.riscv64.QEMU.Generic.qcow2.gz](https://openkoji.iscas.ac.cn/pub/dist-repos/releases/42/Spins/riscv64/images/QEMU/Generic/Fedora-Minimal-bootc-42-20250617000000.riscv64.QEMU.Generic.qcow2.gz)

## fastfetch information

```
[root@fedora ~]# fastfetch
             .',;::::;,'.                 root@fedora
         .';:cccccccccccc:;,.             -----------
      .;cccccccccccccccccccccc;.          OS: Fedora Linux 42 (Adams Prerelease) riscv64
    .:cccccccccccccccccccccccccc:.        Host: riscv-virtio,qemu
  .;ccccccccccccc;.:dddl:.;ccccccc;.      Kernel: Linux 6.14.0-63.fc42.riscv64
 .:ccccccccccccc;OWMKOOXMWd;ccccccc:.     Uptime: 1 min
.:ccccccccccccc;KMMc;cc;xMMc;ccccccc:.    Packages: 498 (rpm)
,cccccccccccccc;MMM.;cc;;WW:;cccccccc,    Shell: bash 5.2.37
:cccccccccccccc;MMM.;cccccccccccccccc:    Terminal: vt220
:ccccccc;oxOOOo;MMM000k.;cccccccccccc:    CPU: rv64gch (4)
cccccc;0MMKxdd:;MMMkddc.;cccccccccccc;    Memory: 280.27 MiB / 5.76 GiB (5%)
ccccc;XMO';cccc;MMM.;cccccccccccccccc'    Swap: Disabled
ccccc;MMo;ccccc;MMW.;ccccccccccccccc;     Disk (/): 6.84 MiB / 6.84 MiB (100%) - overlay [Read-only]
ccccc;0MNc.ccc.xMMd;ccccccccccccccc;      Disk (/sysroot): 3.21 GiB / 8.28 GiB (39%) - ext4 [Read-only]
cccccc;dNMWXXXWM0:;cccccccccccccc:,       Local IP (eth0): 10.0.*.*/24
cccccccc;.:odl:.;cccccccccccccc:,.        Locale: C.UTF-8
ccccccccccccccccccccccccccccc:'.
:ccccccccccccccccccccccc:;,..
 ':cccccccccccccccc::;,.
[root@fedora ~]#
```

## Cross-Architecture Builds (Failed)
Attempting to build a riscv64 image from an x86_64 host currently fails(image builder's base image: `registry.fedoraproject.org/fedora:42`). The build command:

```
podman run \
    --rm \
    -it \
    --privileged \
    --pull=newer \
    --security-opt label=type:unconfined_t \
    -v $(pwd)/output:/output \
    -v /var/lib/containers/storage:/var/lib/containers/storage \
    docker.io/fedorariscv/bootc-image-builder:latest \
    --local \
    --rootfs ext4 \
    --progress verbose \
    --type qcow2 \
    --target-arch riscv64 \
    docker.io/fedorariscv/bootc:42
```

with an error messgaes:

```
Error: failed to get new shm lock manager: failed to create 2048 locks in /libpod_lock: operation not supported

Traceback (most recent call last):
  File "/run/osbuild/bin/org.osbuild.bootc.install-to-filesystem", line 53, in <module>
    r = main(args["options"], args["inputs"], args["paths"])
  File "/run/osbuild/bin/org.osbuild.bootc.install-to-filesystem", line 48, in main
    subprocess.run(pargs, env=env, check=True)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['bootc', 'install', 'to-filesystem', '--source-imgref', 'containers-storage:[overlay@/run/osbuild/containers/storage+/run/containers/storage]2c1b8672d2be7f49f7c21520b14c438bef93b981c2a1768db9004150bed33a24', '--skip-fetch-check', '--generic-image', '--karg', 'rw', '--karg', 'console=tty0', '--karg', 'console=ttyS0', '--target-imgref', 'docker.io/fedorariscv/bootc:42', '/run/osbuild/mounts']' returned non-zero exit status 1.
```

