### PR TITLE
bib: fix `TestManifestSerialization` tests

### DIFF
--- a/bib/cmd/bootc-image-builder/main_test.go
+++ b/bib/cmd/bootc-image-builder/main_test.go
@@ -211,6 +211,9 @@ var diskContainers = map[string][]container.Spec{
 	"image": {
 		containerSpec,
 	},
+	"target": {
+		containerSpec,
+	},
 }
 
 // TODO: this tests at this layer is not ideal, it has too much knowledge


### PR DESCRIPTION
With https://github.com/osbuild/images/pull/1571 merged we now potentially have an extra `target` build pipeline that needs container specs.

Sadly a misconfiguration in the branch protection for "main" merged images v0.151 with the now broken unit tests in https://github.com/osbuild/bootc-image-builder/pull/955 (the branch protection is now fixed).

This commit now also fixes the test by adding a mock container spec for the "target" pipeline.