### PR TITLE
Revert "test: disable anaconda-iso C10S test for now"

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -100,9 +100,7 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             # a bit more stable
             # TestCaseFedora(image="anaconda-iso", sign=True),
             TestCaseC9S(image="anaconda-iso"),
-            # 2025-06-23: disable because of:
-            # https://github.com/osbuild/bootc-image-builder/issues/965
-            # TestCaseC10S(image="anaconda-iso"),
+            TestCaseC10S(image="anaconda-iso"),
         ]
     if what == "qemu-cross":
         test_cases = []


### PR DESCRIPTION
This reverts commit e37bb8350b98900b2c2682319544eeeee7e00ecf.

Because https://github.com/osbuild/bootc-image-builder/issues/965 seems to be fixed.