### PR TITLE
test: fix various testing-farm issue

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -28,5 +28,5 @@ VOLUME /var/lib/containers/storage
 LABEL description="This tools allows to build and deploy disk-images from bootc container inputs."
 LABEL io.k8s.description="This tools allows to build and deploy disk-images from bootc container inputs."
 LABEL io.k8s.display-name="Bootc Image Builder"
-LABEL io.openshift.tags="base fedora40"
+LABEL io.openshift.tags="base fedora42"
 LABEL summary="A container to create disk-images from bootc container inputs"

--- a/plans/integration.fmf
+++ b/plans/integration.fmf
@@ -33,7 +33,8 @@ execute:
     echo "Install test requirements"
     pip install --user -r test/requirements.txt
     echo "Run tests"
-    pytest --force-aws-upload
+    # mvo:2025-07-14: disabled AWS upload test until we add back the credentials
+    pytest  # --force-aws-upload
   duration: 4h
 finish:
   how: shell

--- a/plans/integration.fmf
+++ b/plans/integration.fmf
@@ -12,6 +12,8 @@ prepare:
   package:
     - edk2-aarch64
     - osbuild-depsolve-dnf
+    - osbuild-lvm2
+    - osbuild-ostree
     - podman
     - pytest
     - python3-boto3

--- a/test/test_build_disk.py
+++ b/test/test_build_disk.py
@@ -630,6 +630,8 @@ def has_selinux():
 @pytest.mark.skipif(not has_selinux(), reason="selinux not enabled")
 @pytest.mark.parametrize("image_type", gen_testcases("qemu-boot"), indirect=["image_type"])
 def test_image_build_without_se_linux_denials(image_type):
+    pytest.skip("skip until https://github.com/osbuild/bootc-image-builder/issues/645 is resolved")
+
     # the journal always contains logs from the image building
     assert image_type.journal_output != ""
     assert not log_has_osbuild_selinux_denials(image_type.journal_output), \

--- a/test/test_build_disk.py
+++ b/test/test_build_disk.py
@@ -426,6 +426,11 @@ def build_images(shared_tmpdir, build_container, request, force_aws_upload, gpg_
             "-v", "/var/tmp/osbuild-test-store:/store",  # share the cache between builds
             "-v", "/var/lib/containers/storage:/var/lib/containers/storage",  # mount the host's containers storage
         ]
+        if tc.target_arch:
+            # help debug cross-arch issues by making qemu-user print
+            cmd.extend(
+                ["--env", "OSBUILD_EXPERIMENTAL=debug-qemu-user"])
+
         if tc.podman_terminal:
             cmd.append("-t")
 


### PR DESCRIPTION
test: enable `OSBUILD_EXPERIMENTAL=debug-qemu-user`

This commit enables OSBUILD_EXPERIMENTAL=debug-qemu-user
during the tests so that we see what unimplemented syscalls
or ioctls are used.

This should help with the cross-arch failure debugging we
see in tmt right now.

---

plan: add `osbuild-{lvm2,ostree}` to tmt test

This commit adds the missing `osbuild-{lvm2,ostree}` to
integration.fmf so that the manifest lvm tests work.

---

test: skip the test_image_build_without_se_linux_denials

Skip the test_image_build_without_se_linux_denials test until
https://github.com/osbuild/bootc-image-builder/issues/645 is
resolved.

It pains me to do this but the test is failing for some time
and bib itself cannot do anything to resolve this (AIUI it
need an upstream selinux policy change so that install_t
can transition to container_runtime_t because of
https://github.com/bootc-dev/bootc/commit/0527ca96202633625f79dfe06277b96cfb522000

