### PR TITLE
github: bump fedora version in testingfarm workflows

### DIFF
--- a/.github/workflows/testingfarm-unit.yml
+++ b/.github/workflows/testingfarm-unit.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Run the tests
       uses: sclorg/testing-farm-as-github-action@v4
       with:
-        compose: Fedora-40
+        compose: Fedora-42
         tmt_plan_regex: "/plans/unit-go"
         api_key: ${{ secrets.TF_API_KEY }}
         git_url: ${{ github.event.pull_request.head.repo.clone_url }}

--- a/.github/workflows/testingfarm.yml
+++ b/.github/workflows/testingfarm.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Run the tests
       uses: sclorg/testing-farm-as-github-action@v4
       with:
-        compose: Fedora-40
+        compose: Fedora-42
         tmt_plan_regex: "/plans/integration"
         api_key: ${{ secrets.TF_API_KEY }}
         git_url: ${{ github.event.pull_request.head.repo.clone_url }}


### PR DESCRIPTION
This commit bumps the `compse:` from Fedora-40 -> Fedora-42 in testingfarm.yml. Its a bit unclear why testingfarm has both this and `plan/unit-go.fmf` where we specify
```yaml
summary: Run all tests inside a VM environment
provision:
  how: virtual
  image: fedora:42
...
```
already.

---

Note that the "Testing farm go unit tests " will only resolve itself after the merge to master because for testing farm we use pull_request_target trigger which gets the workflow file from "main" instead of the branch for safety reasons.