### PR TITLE
deps: bump images to 0.164

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -3,12 +3,10 @@ module github.com/osbuild/bootc-image-builder/bib
 go 1.23.9
 
 require (
-	github.com/BurntSushi/toml v1.5.1-0.20250403130103-3d3abc24416a
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/hashicorp/go-version v1.7.0
-	github.com/osbuild/blueprint v1.10.0
 	github.com/osbuild/image-builder-cli v0.0.0-20250331194259-63bb56e12db3
-	github.com/osbuild/images v0.163.0
+	github.com/osbuild/images v0.164.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
@@ -19,6 +17,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.1 // indirect
+	github.com/BurntSushi/toml v1.5.1-0.20250403130103-3d3abc24416a // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.9 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
@@ -96,6 +95,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.12.0 // indirect
+	github.com/osbuild/blueprint v1.10.0 // indirect
 	github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -239,8 +239,8 @@ github.com/osbuild/blueprint v1.10.0 h1:6TG+mSV5kUA3Vq+0fc10MchDilBcDd8SEA8KbDFU
 github.com/osbuild/blueprint v1.10.0/go.mod h1:uknOfX/bAoi+dbeNJj+uAir1T++/LVEtoY8HO3U7MiQ=
 github.com/osbuild/image-builder-cli v0.0.0-20250331194259-63bb56e12db3 h1:M3yYunKH4quwJLQrnFo7dEwCTKorafNC+AUqAo7m5Yo=
 github.com/osbuild/image-builder-cli v0.0.0-20250331194259-63bb56e12db3/go.mod h1:0sEmiQiMo1ChSuOoeONN0RmsoZbQEvj2mlO2448gC5w=
-github.com/osbuild/images v0.163.0 h1:JPA8DY5rAr8qcmfSH5CHFl7HPtcc0G7gvw13C2M0NGc=
-github.com/osbuild/images v0.163.0/go.mod h1:/akyaFWxh7IN0ezlXB+6F4N/rKi/Vod1RAh8XLNzCKE=
+github.com/osbuild/images v0.164.0 h1:FfrAmuwcL1peGsMHko2zeAN+6g6lDBY9cLVM6vacPPY=
+github.com/osbuild/images v0.164.0/go.mod h1:/akyaFWxh7IN0ezlXB+6F4N/rKi/Vod1RAh8XLNzCKE=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
We have an issue where `%post` scripts are not being executed due to our incorrect handling of Anaconda modules [1].

[1]: https://github.com/osbuild/bootc-image-builder/issues/968