### PR TITLE
github: publish upstream container to ghcr

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,14 +3,19 @@ name: Build containers
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
   # for merge queue
   merge_group:
+  push:
+    branches: [main]
 
 env:
+  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build:
@@ -25,3 +30,19 @@ jobs:
           image: ${{ env.IMAGE_NAME }}
           tags: "latest"
           containerfiles: Containerfile
+
+      - name: Log in to the Container registry
+        if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.ref == 'refs/heads/main' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to GitHub Container Repository
+        if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.ref == 'refs/heads/main' }}
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: "latest"
+          registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
At some point we stopped building and pushing the container to ghcr to focus on having only Konflux builds and a single source of the upstream (though, more like "midstream") container on quay.io.  However, Konflux builds are not entirely reliable and are inaccessible to external users and contributors.  So while the container itself is publicly available under the quay.io/centos-bootc namespace, investigating (and solving) build failures requires contacting people with access to the private job logs.

Re-enabling ghcr builds allows us (and practically anyone) to easily investigate and solve build failures and gives us a reliable upstream container available shortly after every PR is merged, making troubleshooting against the latest version a lot easier.

This reverts commit 62dda279dae875539436f30aafc5edd45b7fb88e.

See also discussion in #1000.