### PR TITLE
Fix partition table type customization being ignored

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.12.0 // indirect
-	github.com/osbuild/blueprint v1.10.0 // indirect
+	github.com/osbuild/blueprint v1.11.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/proglottis/gpgme v0.1.4 // indirect

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -207,8 +207,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
-github.com/osbuild/blueprint v1.10.0 h1:6TG+mSV5kUA3Vq+0fc10MchDilBcDd8SEA8KbDFUn2w=
-github.com/osbuild/blueprint v1.10.0/go.mod h1:uknOfX/bAoi+dbeNJj+uAir1T++/LVEtoY8HO3U7MiQ=
+github.com/osbuild/blueprint v1.11.0 h1:Crqt+RRSE84JOoajzTIGrQaXXxnAgGUCDYe3nump54g=
+github.com/osbuild/blueprint v1.11.0/go.mod h1:uknOfX/bAoi+dbeNJj+uAir1T++/LVEtoY8HO3U7MiQ=
 github.com/osbuild/image-builder-cli v0.0.0-20250331194259-63bb56e12db3 h1:M3yYunKH4quwJLQrnFo7dEwCTKorafNC+AUqAo7m5Yo=
 github.com/osbuild/image-builder-cli v0.0.0-20250331194259-63bb56e12db3/go.mod h1:0sEmiQiMo1ChSuOoeONN0RmsoZbQEvj2mlO2448gC5w=
 github.com/osbuild/images v0.168.0 h1:qPmm9d28Py8/TrfzzyCjHAOdcXG4//NbF1EO3I8NanA=

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -631,6 +631,28 @@ def test_manifest_disk_customization_lvm(tmp_path, build_container):
     assert st["devices"]["rootlv"]["type"] == "org.osbuild.lvm2.lv"
 
 
+def test_manifest_disk_customization_dos(tmp_path, build_container):
+    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
+    testutil.pull_container(container_ref)
+
+    config = textwrap.dedent("""\
+    [customizations.disk]
+    type = "dos"
+    """)
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(config)
+
+    testutil.pull_container(container_ref)
+    output = subprocess.check_output([
+        *testutil.podman_run_common,
+        "-v", f"{config_path}:/config.toml:ro",
+        build_container,
+        "manifest", f"{container_ref}",
+    ])
+    st = find_sfdisk_stage_from(output)
+    assert st["label"] == "dos"
+
+
 def test_manifest_disk_customization_btrfs(tmp_path, build_container):
     container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
 


### PR DESCRIPTION
**go.mod: update osbuild/blueprint to v1.11.0**

Fixes #1004

---

**test: add manifest test for partition table type**


---
