### PR TITLE
bib: set the boot mode to UEFI only for aarch64

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -310,10 +310,16 @@ func genPartitionTableDiskCust(c *ManifestConfig, diskCust *blueprint.DiskCustom
 	if err != nil {
 		return nil, err
 	}
+
+	bootMode := platform.BOOT_HYBRID
+	if c.Architecture == arch.ARCH_AARCH64 {
+		// This prevents the creation of BIOS boot partitions for ARM devices
+		bootMode = platform.BOOT_UEFI
+	}
 	partOptions := &disk.CustomPartitionTableOptions{
 		PartitionTableType: basept.Type,
 		// XXX: not setting/defaults will fail to boot with btrfs/lvm
-		BootMode:         platform.BOOT_HYBRID,
+		BootMode:         bootMode,
 		DefaultFSType:    defaultFSType,
 		RequiredMinSizes: requiredMinSizes,
 		Architecture:     c.Architecture,


### PR DESCRIPTION
Setting it to hybrid creates the BIOS boot partition (1 MiB empty partition at the start of the partition table), which can cause boot issues with certain devices.