### PR TITLE
bib: simplify extractTLSKeys()

### DIFF
--- a/bib/cmd/bootc-image-builder/export_test.go
+++ b/bib/cmd/bootc-image-builder/export_test.go
@@ -20,3 +20,11 @@ func MockOsGetuid(new func() int) (restore func()) {
 		osGetuid = saved
 	}
 }
+
+func MockOsReadFile(new func(string) ([]byte, error)) (restore func()) {
+	saved := osReadFile
+	osReadFile = new
+	return func() {
+		osReadFile = saved
+	}
+}

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -347,7 +347,7 @@ func manifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progress
 		return nil, nil, err
 	}
 
-	mTLS, err := extractTLSKeys(SimpleFileReader{}, repos)
+	mTLS, err := extractTLSKeys(repos)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/bib/cmd/bootc-image-builder/mtls.go
+++ b/bib/cmd/bootc-image-builder/mtls.go
@@ -15,17 +15,9 @@ type mTLSConfig struct {
 	ca   []byte
 }
 
-type fileReader interface {
-	ReadFile(string) ([]byte, error)
-}
+var osReadFile = os.ReadFile
 
-type SimpleFileReader struct{}
-
-func (SimpleFileReader) ReadFile(path string) ([]byte, error) {
-	return os.ReadFile(path)
-}
-
-func extractTLSKeys(reader fileReader, repoSets map[string][]rpmmd.RepoConfig) (*mTLSConfig, error) {
+func extractTLSKeys(repoSets map[string][]rpmmd.RepoConfig) (*mTLSConfig, error) {
 	var keyPath, certPath, caPath string
 	for _, set := range repoSets {
 		for _, r := range set {
@@ -44,17 +36,17 @@ func extractTLSKeys(reader fileReader, repoSets map[string][]rpmmd.RepoConfig) (
 		return nil, nil
 	}
 
-	key, err := reader.ReadFile(keyPath)
+	key, err := osReadFile(keyPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read TLS client key from the container: %w", err)
 	}
 
-	cert, err := reader.ReadFile(certPath)
+	cert, err := osReadFile(certPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read TLS client certificate from the container: %w", err)
 	}
 
-	ca, err := reader.ReadFile(caPath)
+	ca, err := osReadFile(caPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read TLS CA certificate from the container: %w", err)
 	}

--- a/bib/cmd/bootc-image-builder/mtls_test.go
+++ b/bib/cmd/bootc-image-builder/mtls_test.go
@@ -33,8 +33,10 @@ func TestExtractTLSKeysHappy(t *testing.T) {
 	}
 
 	fakeReader := &fakeFileReader{}
+	restore := MockOsReadFile(fakeReader.ReadFile)
+	defer restore()
 
-	mTLS, err := extractTLSKeys(fakeReader, repos)
+	mTLS, err := extractTLSKeys(repos)
 	require.NoError(t, err)
 	require.Equal(t, mTLS.ca, []byte("content of /ca"))
 	require.Equal(t, mTLS.cert, []byte("content of /cert"))
@@ -43,7 +45,7 @@ func TestExtractTLSKeysHappy(t *testing.T) {
 
 	// also check that adding another repo with same keys still succeeds
 	repos["toucan"] = repos["kingfisher"]
-	_, err = extractTLSKeys(fakeReader, repos)
+	_, err = extractTLSKeys(repos)
 	require.NoError(t, err)
 	require.Len(t, fakeReader.readPaths, 6)
 }
@@ -68,8 +70,10 @@ func TestExtractTLSKeysUnhappy(t *testing.T) {
 	}
 
 	fakeReader := &fakeFileReader{}
+	restore := MockOsReadFile(fakeReader.ReadFile)
+	defer restore()
 
-	_, err := extractTLSKeys(fakeReader, repos)
+	_, err := extractTLSKeys(repos)
 	require.EqualError(t, err, "multiple TLS client keys found, this is currently unsupported")
 }
 


### PR DESCRIPTION
The extractTLSKeys() takes a SimplefileReader so that its testable. The downside is that it makes it slightly harder to use the helper because of the extra parameter.

But we don't really need this, we can make the testing entirely invisible for the API user via the common
```go
var osReadFile = os.ReadFile
```
pattern.

This commit is doing exactly this.