### PR TITLE
test: disable centos9 iso test for now because kernel panic

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -99,7 +99,8 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             # 2024-12-19: disabled for now until the mirror situation becomes
             # a bit more stable
             # TestCaseFedora(image="anaconda-iso", sign=True),
-            TestCaseC9S(image="anaconda-iso"),
+            # 2025-08-21: disabled because of https://issues.redhat.com/browse/RHEL-109635
+            # TestCaseC9S(image="anaconda-iso"),
             TestCaseC10S(image="anaconda-iso"),
         ]
     if what == "qemu-cross":


### PR DESCRIPTION
This commit disables the centos9 iso test because it currently crashes the centos9 kernel, see
https://issues.redhat.com/browse/RHEL-109635

This unbreaks bib merges and should be reverted once RHEL-109635 is fixed.