### PR TITLE
Revert "test: disable centos9 iso test for now because kernel  panic"

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -97,8 +97,7 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
     if what == "anaconda-iso":
         return [
             TestCaseFedora(image="anaconda-iso", sign=True),
-            # 2025-08-21: disabled because of https://issues.redhat.com/browse/RHEL-109635
-            # TestCaseC9S(image="anaconda-iso"),
+            TestCaseC9S(image="anaconda-iso"),
             TestCaseC10S(image="anaconda-iso"),
         ]
     if what == "qemu-cross":


### PR DESCRIPTION
[draft because we obviously can only revert this once https://issues.redhat.com/browse/RHEL-109635 is fixed but opening it so that this is not forgotten]

This reverts commit 70f03adc0dec7dcd15b7476e00fd1c3975930c57.

(c.f. https://github.com/osbuild/bootc-image-builder/pull/1019)