### PR TITLE
bib: Add Rocky Linux symlinks for version 9 and 10

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -486,7 +486,13 @@ func labelForISO(os *osinfo.OSRelease, arch *arch.Arch) string {
 }
 
 func needsRHELLoraxTemplates(si osinfo.OSRelease) bool {
-	return si.ID == "rhel" || slices.Contains(si.IDLike, "rhel") || si.VersionID == "eln"
+	// Explicitly handle RHEL-compatible distributions by ID
+	if si.ID == "rhel" || si.ID == "rocky" || si.ID == "almalinux" || si.VersionID == "eln" {
+		return true
+	}
+	
+	// Also check ID_LIKE for other RHEL derivatives (e.g., CentOS)
+	return slices.Contains(si.IDLike, "rhel")
 }
 
 func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, error) {

--- a/bib/data/defs/rocky-10.yaml
+++ b/bib/data/defs/rocky-10.yaml
@@ -1,0 +1,1 @@
+centos-10.yaml

--- a/bib/data/defs/rocky-9.yaml
+++ b/bib/data/defs/rocky-9.yaml
@@ -1,0 +1,1 @@
+centos-9.yaml


### PR DESCRIPTION
- Create rocky-9.yaml symlink pointing to centos-9.yaml
- Create rocky-10.yaml symlink pointing to centos-10.yaml

This allows Rocky Linux to reuse the existing CentOS definitions for bootc image building.