### PR TITLE
test: re-enable the fedora 42 iso test

### DIFF
--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -58,7 +58,9 @@ def test_iso_manifest_smoke(build_container, tc):
         *testutil.podman_run_common,
         build_container,
         "manifest",
-        "--type=anaconda-iso", f"{tc.container_ref}",
+        *tc.bib_rootfs_args(),
+        "--type=anaconda-iso",
+        f"{tc.container_ref}",
     ])
     manifest = json.loads(output)
     # just some basic validation

--- a/test/testcases.py
+++ b/test/testcases.py
@@ -96,9 +96,7 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
         return [TestCaseC9S(image="ami"), TestCaseFedora(image="ami")]
     if what == "anaconda-iso":
         return [
-            # 2024-12-19: disabled for now until the mirror situation becomes
-            # a bit more stable
-            # TestCaseFedora(image="anaconda-iso", sign=True),
+            TestCaseFedora(image="anaconda-iso", sign=True),
             # 2025-08-21: disabled because of https://issues.redhat.com/browse/RHEL-109635
             # TestCaseC9S(image="anaconda-iso"),
             TestCaseC10S(image="anaconda-iso"),


### PR DESCRIPTION
We had this test disabled for a while because the mirror situation was not very stable. With librepo by default and some time having passed we should try it again.