### PR TITLE
bib: fix AWS upload with empty target-arch

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -386,9 +386,13 @@ func handleAWSFlags(cmd *cobra.Command) (cloud.Uploader, error) {
 	}
 
 	// check as many permission prerequisites as possible before starting
-	targetArch, err := arch.FromString(targetArchStr)
-	if err != nil {
-		return nil, err
+	targetArch := arch.Current()
+	if targetArchStr != "" {
+		var err error
+		targetArch, err = arch.FromString(targetArchStr)
+		if err != nil {
+			return nil, err
+		}
 	}
 	uploaderOpts := &awscloud.UploaderOptions{
 		TargetArch: targetArch,

--- a/bib/cmd/upload/main.go
+++ b/bib/cmd/upload/main.go
@@ -33,8 +33,12 @@ func uploadAMI(cmd *cobra.Command, args []string) {
 	targetArchStr, err := flags.GetString("target-arch")
 	check(err)
 
-	targetArch, err := arch.FromString(targetArchStr)
-	check(err)
+	targetArch := arch.Current()
+	if targetArchStr != "" {
+		var err error
+		targetArch, err = arch.FromString(targetArchStr)
+		check(err)
+	}
 	opts := &awscloud.UploaderOptions{
 		TargetArch: targetArch,
 	}


### PR DESCRIPTION
This commit fixes the issue that with an unset --target-arch the code will try to convert an empty string to an arch.Arch which then fails. This is a regression from
https://github.com/osbuild/bootc-image-builder/pull/1017 that was not caught.

Closes: https://github.com/osbuild/bootc-image-builder/issues/1029