### PR TITLE
github: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+*               @osbuild/osbuild-reviewers
+


### PR DESCRIPTION
Add the osbuild-reviewers team as code owners for automatic review assignment.

@osbuild/osbuild-reviewers, take a look.