### PR TITLE
deps: update images to 0.191.0

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/osbuild/images/pkg/cloud/awscloud"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/distro/bootc"
-	"github.com/osbuild/images/pkg/dnfjson"
+	"github.com/osbuild/images/pkg/depsolvednf"
 	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/manifestgen"
@@ -93,7 +93,7 @@ func inContainerOrUnknown() bool {
 	return err == nil
 }
 
-func makeManifest(c *ManifestConfig, solver *dnfjson.Solver, cacheRoot string) (manifest.OSBuildManifest, map[string][]rpmmd.RepoConfig, error) {
+func makeManifest(c *ManifestConfig, solver *depsolvednf.Solver, cacheRoot string) (manifest.OSBuildManifest, map[string][]rpmmd.RepoConfig, error) {
 	rng := createRand()
 	mani, err := manifestForISO(c, rng)
 	if err != nil {
@@ -101,7 +101,7 @@ func makeManifest(c *ManifestConfig, solver *dnfjson.Solver, cacheRoot string) (
 	}
 
 	// depsolve packages
-	depsolvedSets := make(map[string]dnfjson.DepsolveResult)
+	depsolvedSets := make(map[string]depsolvednf.DepsolveResult)
 	depsolvedRepos := make(map[string][]rpmmd.RepoConfig)
 	for name, pkgSet := range mani.GetPackageSetChains() {
 		res, err := solver.Depsolve(pkgSet, 0)

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/osbuild/blueprint v1.13.0
 	github.com/osbuild/image-builder-cli v0.0.0-20250331194259-63bb56e12db3
-	github.com/osbuild/images v0.189.0
+	github.com/osbuild/images v0.191.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -245,8 +245,8 @@ github.com/osbuild/blueprint v1.13.0 h1:blo22+S2ZX5bBmjGcRveoTUrV4Ms7kLfKyb32Wyu
 github.com/osbuild/blueprint v1.13.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
 github.com/osbuild/image-builder-cli v0.0.0-20250331194259-63bb56e12db3 h1:M3yYunKH4quwJLQrnFo7dEwCTKorafNC+AUqAo7m5Yo=
 github.com/osbuild/image-builder-cli v0.0.0-20250331194259-63bb56e12db3/go.mod h1:0sEmiQiMo1ChSuOoeONN0RmsoZbQEvj2mlO2448gC5w=
-github.com/osbuild/images v0.189.0 h1:fG9J9bxhdzkKkZ2EpW/LzT0YQBXY/kKiT99UpEzZhCo=
-github.com/osbuild/images v0.189.0/go.mod h1:KPiYBF0VrOXz5NAw6Lv4X170uN8wnOHpWuBzKT4jPrU=
+github.com/osbuild/images v0.191.0 h1:nhTIAf0JJTEf1gIUsU1II0BVIYBj537BvDpBBXCLYig=
+github.com/osbuild/images v0.191.0/go.mod h1:KPiYBF0VrOXz5NAw6Lv4X170uN8wnOHpWuBzKT4jPrU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -153,8 +153,7 @@ def test_manifest_cross_arch_check(tmp_path, build_container):
                 "manifest", "--target-arch=aarch64",
                 f"localhost/{container_tag}"
             ], check=True, capture_output=True, encoding="utf8")
-        assert 'cannot generate manifest: requested container architecture '\
-            'does not match resolved container: "x86_64" !=' in exc.value.stderr
+        assert 'cannot generate manifest: invalid arch: aarch64' in exc.value.stderr
 
 
 def find_rootfs_type_from(manifest_str):


### PR DESCRIPTION
Bump the images dependency to 0.191.0 and handle the rename of `dnfjson` to `depsolvednf`.