### PR TITLE
test: disable cross arch test for now

### DIFF
--- a/test/testcases.py
+++ b/test/testcases.py
@@ -104,8 +104,11 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
     if what == "qemu-cross":
         test_cases = []
         if platform.machine() == "x86_64":
-            test_cases.append(
-                TestCaseC9S(image="raw", target_arch="arm64"))
+            # 2025-09-19: disabled because CI hangs, see
+            # https://github.com/osbuild/bootc-image-builder/actions/runs/17821609665
+            #test_cases.append(
+            #    TestCaseC9S(image="raw", target_arch="arm64"))
+            pass
         elif platform.machine() == "arm64":
             # TODO: add arm64->x86_64 cross build test too
             pass


### PR DESCRIPTION
This commit drops the cross arch test for now. It keeps failing in the GH action with:
```
ERROR    paramiko.transport:transport.py:1904 Exception (client): Error reading SSH protocol banner
ERROR    paramiko.transport:transport.py:1902 Traceback (most recent call last):
ERROR    paramiko.transport:transport.py:1902   File "/usr/lib/python3/dist-packages/paramiko/transport.py", line 2320, in _check_banner
ERROR    paramiko.transport:transport.py:1902     buf = self.packetizer.readline(timeout)
ERROR    paramiko.transport:transport.py:1902           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR    paramiko.transport:transport.py:1902   File "/usr/lib/python3/dist-packages/paramiko/packet.py", line 387, in readline
ERROR    paramiko.transport:transport.py:1902     buf += self._read_timeout(timeout)
ERROR    paramiko.transport:transport.py:1902            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR    paramiko.transport:transport.py:1902   File "/usr/lib/python3/dist-packages/paramiko/packet.py", line 624, in _read_timeout
ERROR    paramiko.transport:transport.py:1902     raise EOFError()
ERROR    paramiko.transport:transport.py:1902 EOFError
ERROR    paramiko.transport:transport.py:1902
ERROR    paramiko.transport:transport.py:1902 During handling of the above exception, another exception occurred:
ERROR    paramiko.transport:transport.py:1902
ERROR    paramiko.transport:transport.py:1902 Traceback (most recent call last):
ERROR    paramiko.transport:transport.py:1902   File "/usr/lib/python3/dist-packages/paramiko/transport.py", line 2138, in run
ERROR    paramiko.transport:transport.py:1902     self._check_banner()
ERROR    paramiko.transport:transport.py:1902   File "/usr/lib/python3/dist-packages/paramiko/transport.py", line 2324, in _check_banner
ERROR    paramiko.transport:transport.py:1902     raise SSHException(
ERROR    paramiko.transport:transport.py:1902 paramiko.ssh_exception.SSHException: Error reading SSH protocol banner
ERROR    paramiko.transport:transport.py:1902
```
and its unclear what is going on. As the cross arch is best effort and this failure is blocking our releases we drop it for now.