### PR TITLE
Add manifest for Rocky Linux 9 and 10

### DIFF
--- a/bib/data/defs/rocky-10.yaml
+++ b/bib/data/defs/rocky-10.yaml
@@ -1,0 +1,1 @@
+centos-10.yaml

--- a/bib/data/defs/rocky-9.yaml
+++ b/bib/data/defs/rocky-9.yaml
@@ -1,0 +1,1 @@
+centos-9.yaml


### PR DESCRIPTION
This fixes #1061 and enables Rocky Linux bootc images to be built using Anaconda ISO as type.

There are no official bootc images for Rocky yet but are very easy to build now with EL9.6 and 10 finally out.