### PR TITLE
bib: mark rpm based ISOs internally as deprecated

### DIFF
--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -23,15 +23,12 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/osbuild/bootc-image-builder/bib/internal/distrodef"
-	"github.com/osbuild/bootc-image-builder/bib/internal/imagetypes"
 )
 
 type ManifestConfig struct {
 	// OCI image path (without the transport, that is always docker://)
 	Imgref      string
 	BuildImgref string
-
-	ImageTypes imagetypes.ImageTypes
 
 	// Build config
 	Config *blueprint.Blueprint

--- a/bib/cmd/bootc-image-builder/image.go
+++ b/bib/cmd/bootc-image-builder/image.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	cryptorand "crypto/rand"
 	"fmt"
-	"math"
-	"math/big"
 	"math/rand"
 	"slices"
 	"strconv"
@@ -255,15 +252,4 @@ func getDistroAndRunner(osRelease osinfo.OSRelease) (manifest.Distro, runner.Run
 
 	logrus.Warnf("Unknown distro %s, using default runner", osRelease.ID)
 	return manifest.DISTRO_NULL, &runner.Linux{}, nil
-}
-
-func createRand() *rand.Rand {
-	seed, err := cryptorand.Int(cryptorand.Reader, big.NewInt(math.MaxInt64))
-	if err != nil {
-		panic("Cannot generate an RNG seed.")
-	}
-
-	// math/rand is good enough in this case
-	/* #nosec G404 */
-	return rand.New(rand.NewSource(seed.Int64()))
 }

--- a/bib/cmd/bootc-image-builder/legacy_iso.go
+++ b/bib/cmd/bootc-image-builder/legacy_iso.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
+	"github.com/osbuild/images/pkg/depsolvednf"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
@@ -22,8 +23,19 @@ import (
 	"github.com/osbuild/images/pkg/runner"
 	"github.com/sirupsen/logrus"
 
+	podman_container "github.com/osbuild/images/pkg/bib/container"
+
 	"github.com/osbuild/bootc-image-builder/bib/internal/distrodef"
 )
+
+// all possible locations for the bib's distro definitions
+// ./data/defs and ./bib/data/defs are for development
+// /usr/share/bootc-image-builder/defs is for the production, containerized version
+var distroDefPaths = []string{
+	"./data/defs",
+	"./bib/data/defs",
+	"/usr/share/bootc-image-builder/defs",
+}
 
 type ManifestConfig struct {
 	// OCI image path (without the transport, that is always docker://)
@@ -48,6 +60,155 @@ type ManifestConfig struct {
 
 	// use librepo ad the rpm downlaod backend
 	UseLibrepo bool
+}
+
+func manifestFromCobraForLegacyISO(imgref, buildImgref, imgTypeStr, rootFs, rpmCacheRoot string, config *blueprint.Blueprint, useLibrepo bool, cntArch arch.Arch) ([]byte, *mTLSConfig, error) {
+	container, err := podman_container.New(imgref)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		if err := container.Stop(); err != nil {
+			logrus.Warnf("error stopping container: %v", err)
+		}
+	}()
+
+	var rootfsType string
+	if rootFs != "" {
+		rootfsType = rootFs
+	} else {
+		rootfsType, err = container.DefaultRootfsType()
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot get rootfs type for container: %w", err)
+		}
+		if rootfsType == "" {
+			return nil, nil, fmt.Errorf(`no default root filesystem type specified in container, please use "--rootfs" to set manually`)
+		}
+	}
+
+	// Gather some data from the containers distro
+	sourceinfo, err := osinfo.Load(container.Root())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	buildContainer := container
+	buildSourceinfo := sourceinfo
+	startedBuildContainer := false
+	defer func() {
+		if startedBuildContainer {
+			if err := buildContainer.Stop(); err != nil {
+				logrus.Warnf("error stopping container: %v", err)
+			}
+		}
+	}()
+
+	if buildImgref != "" {
+		buildContainer, err = podman_container.New(buildImgref)
+		if err != nil {
+			return nil, nil, err
+		}
+		startedBuildContainer = true
+
+		// Gather some data from the containers distro
+		buildSourceinfo, err = osinfo.Load(buildContainer.Root())
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		buildImgref = imgref
+	}
+
+	// This is needed just for RHEL and RHSM in most cases, but let's run it every time in case
+	// the image has some non-standard dnf plugins.
+	if err := buildContainer.InitDNF(); err != nil {
+		return nil, nil, err
+	}
+	solver, err := buildContainer.NewContainerSolver(rpmCacheRoot, cntArch, sourceinfo)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	manifestConfig := &ManifestConfig{
+		Architecture:    cntArch,
+		Config:          config,
+		Imgref:          imgref,
+		BuildImgref:     buildImgref,
+		DistroDefPaths:  distroDefPaths,
+		SourceInfo:      sourceinfo,
+		BuildSourceInfo: buildSourceinfo,
+		RootFSType:      rootfsType,
+		UseLibrepo:      useLibrepo,
+	}
+
+	manifest, repos, err := makeISOManifest(manifestConfig, solver, rpmCacheRoot)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mTLS, err := extractTLSKeys(repos)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return manifest, mTLS, nil
+}
+
+func makeISOManifest(c *ManifestConfig, solver *depsolvednf.Solver, cacheRoot string) (manifest.OSBuildManifest, map[string][]rpmmd.RepoConfig, error) {
+	rng := createRand()
+	mani, err := manifestForISO(c, rng)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot get manifest: %w", err)
+	}
+
+	// depsolve packages
+	depsolvedSets := make(map[string]depsolvednf.DepsolveResult)
+	depsolvedRepos := make(map[string][]rpmmd.RepoConfig)
+	for name, pkgSet := range mani.GetPackageSetChains() {
+		res, err := solver.Depsolve(pkgSet, 0)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot depsolve: %w", err)
+		}
+		depsolvedSets[name] = *res
+		depsolvedRepos[name] = res.Repos
+	}
+
+	// Resolve container - the normal case is that host and target
+	// architecture are the same. However it is possible to build
+	// cross-arch images by using qemu-user. This will run everything
+	// (including the build-root) with the target arch then, it
+	// is fast enough (given that it's mostly I/O and all I/O is
+	// run naively via syscall translation)
+
+	// XXX: should NewResolver() take "arch.Arch"?
+	resolver := container.NewResolver(c.Architecture.String())
+
+	containerSpecs := make(map[string][]container.Spec)
+	for plName, sourceSpecs := range mani.GetContainerSourceSpecs() {
+		for _, c := range sourceSpecs {
+			resolver.Add(c)
+		}
+		specs, err := resolver.Finish()
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot resolve containers: %w", err)
+		}
+		for _, spec := range specs {
+			if spec.Arch != c.Architecture {
+				return nil, nil, fmt.Errorf("image found is for unexpected architecture %q (expected %q), if that is intentional, please make sure --target-arch matches", spec.Arch, c.Architecture)
+			}
+		}
+		containerSpecs[plName] = specs
+	}
+
+	var opts manifest.SerializeOptions
+	if c.UseLibrepo {
+		opts.RpmDownloader = osbuild.RpmDownloaderLibrepo
+	}
+	mf, err := mani.Serialize(depsolvedSets, containerSpecs, nil, &opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("[ERROR] manifest serialization failed: %s", err.Error())
+	}
+	return mf, depsolvedRepos, nil
 }
 
 func labelForISO(os *osinfo.OSRelease, arch *arch.Arch) string {

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -26,32 +26,18 @@ import (
 	"github.com/osbuild/images/pkg/bib/blueprintload"
 	"github.com/osbuild/images/pkg/cloud"
 	"github.com/osbuild/images/pkg/cloud/awscloud"
-	"github.com/osbuild/images/pkg/container"
-	"github.com/osbuild/images/pkg/depsolvednf"
 	"github.com/osbuild/images/pkg/distro/bootc"
 	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/manifestgen"
-	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/reporegistry"
 	"github.com/osbuild/images/pkg/rpmmd"
 
-	"github.com/osbuild/bootc-image-builder/bib/internal/imagetypes"
-	podman_container "github.com/osbuild/images/pkg/bib/container"
-	"github.com/osbuild/images/pkg/bib/osinfo"
-
 	"github.com/osbuild/image-builder-cli/pkg/progress"
 	"github.com/osbuild/image-builder-cli/pkg/setup"
-)
 
-// all possible locations for the bib's distro definitions
-// ./data/defs and ./bib/data/defs are for development
-// /usr/share/bootc-image-builder/defs is for the production, containerized version
-var distroDefPaths = []string{
-	"./data/defs",
-	"./bib/data/defs",
-	"/usr/share/bootc-image-builder/defs",
-}
+	"github.com/osbuild/bootc-image-builder/bib/internal/imagetypes"
+)
 
 var (
 	osGetuid = os.Getuid
@@ -69,63 +55,6 @@ func inContainerOrUnknown() bool {
 	// exit code "0" means the container is detected
 	err := exec.Command("systemd-detect-virt", "-c", "-q").Run()
 	return err == nil
-}
-
-func makeISOManifest(c *ManifestConfig, solver *depsolvednf.Solver, cacheRoot string) (manifest.OSBuildManifest, map[string][]rpmmd.RepoConfig, error) {
-	rng := createRand()
-	mani, err := manifestForISO(c, rng)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot get manifest: %w", err)
-	}
-
-	// depsolve packages
-	depsolvedSets := make(map[string]depsolvednf.DepsolveResult)
-	depsolvedRepos := make(map[string][]rpmmd.RepoConfig)
-	for name, pkgSet := range mani.GetPackageSetChains() {
-		res, err := solver.Depsolve(pkgSet, 0)
-		if err != nil {
-			return nil, nil, fmt.Errorf("cannot depsolve: %w", err)
-		}
-		depsolvedSets[name] = *res
-		depsolvedRepos[name] = res.Repos
-	}
-
-	// Resolve container - the normal case is that host and target
-	// architecture are the same. However it is possible to build
-	// cross-arch images by using qemu-user. This will run everything
-	// (including the build-root) with the target arch then, it
-	// is fast enough (given that it's mostly I/O and all I/O is
-	// run naively via syscall translation)
-
-	// XXX: should NewResolver() take "arch.Arch"?
-	resolver := container.NewResolver(c.Architecture.String())
-
-	containerSpecs := make(map[string][]container.Spec)
-	for plName, sourceSpecs := range mani.GetContainerSourceSpecs() {
-		for _, c := range sourceSpecs {
-			resolver.Add(c)
-		}
-		specs, err := resolver.Finish()
-		if err != nil {
-			return nil, nil, fmt.Errorf("cannot resolve containers: %w", err)
-		}
-		for _, spec := range specs {
-			if spec.Arch != c.Architecture {
-				return nil, nil, fmt.Errorf("image found is for unexpected architecture %q (expected %q), if that is intentional, please make sure --target-arch matches", spec.Arch, c.Architecture)
-			}
-		}
-		containerSpecs[plName] = specs
-	}
-
-	var opts manifest.SerializeOptions
-	if c.UseLibrepo {
-		opts.RpmDownloader = osbuild.RpmDownloaderLibrepo
-	}
-	mf, err := mani.Serialize(depsolvedSets, containerSpecs, nil, &opts)
-	if err != nil {
-		return nil, nil, fmt.Errorf("[ERROR] manifest serialization failed: %s", err.Error())
-	}
-	return mf, depsolvedRepos, nil
 }
 
 func saveManifest(ms manifest.OSBuildManifest, fpath string) (err error) {
@@ -271,99 +200,6 @@ func manifestFromCobraForDisk(imgref, buildImgref, imgTypeStr, rootFs, rpmCacheR
 		return nil, nil, err
 	}
 	return buf.Bytes(), nil, nil
-
-}
-
-func manifestFromCobraForISO(imgref, buildImgref, imgTypeStr, rootFs, rpmCacheRoot string, config *blueprint.Blueprint, useLibrepo bool, cntArch arch.Arch) ([]byte, *mTLSConfig, error) {
-	container, err := podman_container.New(imgref)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer func() {
-		if err := container.Stop(); err != nil {
-			logrus.Warnf("error stopping container: %v", err)
-		}
-	}()
-
-	var rootfsType string
-	if rootFs != "" {
-		rootfsType = rootFs
-	} else {
-		rootfsType, err = container.DefaultRootfsType()
-		if err != nil {
-			return nil, nil, fmt.Errorf("cannot get rootfs type for container: %w", err)
-		}
-		if rootfsType == "" {
-			return nil, nil, fmt.Errorf(`no default root filesystem type specified in container, please use "--rootfs" to set manually`)
-		}
-	}
-
-	// Gather some data from the containers distro
-	sourceinfo, err := osinfo.Load(container.Root())
-	if err != nil {
-		return nil, nil, err
-	}
-
-	buildContainer := container
-	buildSourceinfo := sourceinfo
-	startedBuildContainer := false
-	defer func() {
-		if startedBuildContainer {
-			if err := buildContainer.Stop(); err != nil {
-				logrus.Warnf("error stopping container: %v", err)
-			}
-		}
-	}()
-
-	if buildImgref != "" {
-		buildContainer, err = podman_container.New(buildImgref)
-		if err != nil {
-			return nil, nil, err
-		}
-		startedBuildContainer = true
-
-		// Gather some data from the containers distro
-		buildSourceinfo, err = osinfo.Load(buildContainer.Root())
-		if err != nil {
-			return nil, nil, err
-		}
-	} else {
-		buildImgref = imgref
-	}
-
-	// This is needed just for RHEL and RHSM in most cases, but let's run it every time in case
-	// the image has some non-standard dnf plugins.
-	if err := buildContainer.InitDNF(); err != nil {
-		return nil, nil, err
-	}
-	solver, err := buildContainer.NewContainerSolver(rpmCacheRoot, cntArch, sourceinfo)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	manifestConfig := &ManifestConfig{
-		Architecture:    cntArch,
-		Config:          config,
-		Imgref:          imgref,
-		BuildImgref:     buildImgref,
-		DistroDefPaths:  distroDefPaths,
-		SourceInfo:      sourceinfo,
-		BuildSourceInfo: buildSourceinfo,
-		RootFSType:      rootfsType,
-		UseLibrepo:      useLibrepo,
-	}
-
-	manifest, repos, err := makeISOManifest(manifestConfig, solver, rpmCacheRoot)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	mTLS, err := extractTLSKeys(repos)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return manifest, mTLS, nil
 }
 
 func cmdManifest(cmd *cobra.Command, args []string) error {

--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -149,10 +149,10 @@ func manifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progress
 
 	// Note that we only need to pass a single imgType here into the manifest generation because:
 	// 1. the bootc disk manifests contains exports for all supported image types
-	// 2. the bootc iso is always a single build
+	// 2. the bootc legacy types (iso, anaconda-iso) always do a single build
 	imgType := imgTypes[0]
-	if imageTypes.BuildsISO() {
-		return manifestFromCobraForISO(imgref, buildImgref, imgType, rootFs, rpmCacheRoot, config, useLibrepo, cntArch)
+	if imageTypes.Legacy() {
+		return manifestFromCobraForLegacyISO(imgref, buildImgref, imgType, rootFs, rpmCacheRoot, config, useLibrepo, cntArch)
 	}
 	return manifestFromCobraForDisk(imgref, buildImgref, imgType, rootFs, rpmCacheRoot, config, useLibrepo, cntArch)
 }

--- a/bib/cmd/bootc-image-builder/util.go
+++ b/bib/cmd/bootc-image-builder/util.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	cryptorand "crypto/rand"
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// canChownInPath checks if the ownership of files can be set in a given path.
+func canChownInPath(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("%s is not a directory", path)
+	}
+
+	checkFile, err := os.CreateTemp(path, ".writecheck")
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if err := os.Remove(checkFile.Name()); err != nil {
+			// print the error message for info but don't error out
+			fmt.Fprintf(os.Stderr, "error deleting %s: %s\n", checkFile.Name(), err.Error())
+		}
+	}()
+	return checkFile.Chown(osGetuid(), osGetgid()) == nil, nil
+}
+
+func chownR(path string, chown string) error {
+	if chown == "" {
+		return nil
+	}
+	errFmt := "cannot parse chown: %v"
+
+	var gid int
+	uidS, gidS, _ := strings.Cut(chown, ":")
+	uid, err := strconv.Atoi(uidS)
+	if err != nil {
+		return fmt.Errorf(errFmt, err)
+	}
+	if gidS != "" {
+		gid, err = strconv.Atoi(gidS)
+		if err != nil {
+			return fmt.Errorf(errFmt, err)
+		}
+	} else {
+		gid = osGetgid()
+	}
+
+	return filepath.Walk(path, func(name string, info os.FileInfo, err error) error {
+		if err == nil {
+			err = os.Chown(name, uid, gid)
+		}
+		return err
+	})
+}
+
+func createRand() *rand.Rand {
+	seed, err := cryptorand.Int(cryptorand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		panic("Cannot generate an RNG seed.")
+	}
+
+	// math/rand is good enough in this case
+	/* #nosec G404 */
+	return rand.New(rand.NewSource(seed.Int64()))
+}

--- a/bib/internal/imagetypes/imagetypes.go
+++ b/bib/internal/imagetypes/imagetypes.go
@@ -10,17 +10,22 @@ import (
 type imageType struct {
 	Export string
 	ISO    bool
+	Legacy bool
 }
 
 var supportedImageTypes = map[string]imageType{
-	"ami":          imageType{Export: "image"},
-	"qcow2":        imageType{Export: "qcow2"},
-	"raw":          imageType{Export: "image"},
-	"vmdk":         imageType{Export: "vmdk"},
-	"vhd":          imageType{Export: "vpc"},
-	"gce":          imageType{Export: "gce"},
-	"anaconda-iso": imageType{Export: "bootiso", ISO: true},
-	"iso":          imageType{Export: "bootiso", ISO: true},
+	// XXX: ideally we would look how to consolidate all
+	// knownledge about disk based image types into the images
+	// library
+	"ami":   imageType{Export: "image"},
+	"qcow2": imageType{Export: "qcow2"},
+	"raw":   imageType{Export: "image"},
+	"vmdk":  imageType{Export: "vmdk"},
+	"vhd":   imageType{Export: "vpc"},
+	"gce":   imageType{Export: "gce"},
+	// the iso image types are RPM based and legacy/deprecated
+	"anaconda-iso": imageType{Export: "bootiso", ISO: true, Legacy: true},
+	"iso":          imageType{Export: "bootiso", ISO: true, Legacy: true},
 }
 
 // Available() returns a comma-separated list of supported image types
@@ -85,4 +90,13 @@ func (it ImageTypes) Exports() []string {
 func (it ImageTypes) BuildsISO() bool {
 	// XXX: this assumes a valid ImagTypes object
 	return supportedImageTypes[it[0]].ISO
+}
+
+func (it ImageTypes) Legacy() bool {
+	for _, name := range it {
+		if supportedImageTypes[name].Legacy {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This PR does some code cleanup/reshuffling to separate the legacy rpm bsased ISO building from the "new" images library manifest creation. Once we support "bootc" based installer containers the "new" images code path will also be used for those.