### PR TITLE
deps: bump images to 0.203.0

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/osbuild/blueprint v1.16.0
 	github.com/osbuild/image-builder-cli v0.0.0-20250924085931-15de5139f521
-	github.com/osbuild/images v0.202.0
+	github.com/osbuild/images v0.203.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -247,6 +247,8 @@ github.com/osbuild/image-builder-cli v0.0.0-20250924085931-15de5139f521 h1:Mo1ht
 github.com/osbuild/image-builder-cli v0.0.0-20250924085931-15de5139f521/go.mod h1:oTn9T+bV9g/760hM/jX7AV0c4vuVIn6FjAnaVM9RzRo=
 github.com/osbuild/images v0.202.0 h1:OPvfmr5RJHcOJgU8Win6kHyoCNQZEiILlgIDI64/YIM=
 github.com/osbuild/images v0.202.0/go.mod h1:xkXfw5CIy0bVNTNdB6GXiewu/IzBgpofkItDJPAzGA4=
+github.com/osbuild/images v0.203.0 h1:G+aFUTY8cXXcptRQesKqEaZtxRr6TUlFGXlEGJycwBM=
+github.com/osbuild/images v0.203.0/go.mod h1:xkXfw5CIy0bVNTNdB6GXiewu/IzBgpofkItDJPAzGA4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
This change includes the usage of `BootMode` that we missed in yesterdays release.