### PR TITLE
iso: disable `gpt-auto` for ISOs (HMS-9524)

### DIFF
--- a/bib/cmd/bootc-image-builder/legacy_iso.go
+++ b/bib/cmd/bootc-image-builder/legacy_iso.go
@@ -317,6 +317,10 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	img.InstallerCustomizations.OSVersion = c.SourceInfo.OSRelease.VersionID
 	img.InstallerCustomizations.ISOLabel = labelForISO(&c.SourceInfo.OSRelease, &c.Architecture)
 
+	// XXX workaround for gpt-auto preventing ISO boot see [1]
+	// [1]: https://github.com/osbuild/images/issues/1947#issuecomment-3395867961
+	img.InstallerCustomizations.KernelOptionsAppend = append(img.InstallerCustomizations.KernelOptionsAppend, "systemd.gpt_auto=0")
+
 	img.ExtraBasePackages = rpmmd.PackageSet{
 		Include: imageDef.Packages,
 	}


### PR DESCRIPTION
Workaround to prevent ISOs from failing to boot when used as disk images in combination with UEFI [1]

See also: https://github.com/osbuild/images/pull/1948

[1]: https://github.com/osbuild/images/issues/1947#issuecomment-3395867961