### PR TITLE
Revert "iso: inhibit `gpt-auto`"

### DIFF
--- a/bib/cmd/bootc-image-builder/legacy_iso.go
+++ b/bib/cmd/bootc-image-builder/legacy_iso.go
@@ -317,10 +317,6 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	img.InstallerCustomizations.OSVersion = c.SourceInfo.OSRelease.VersionID
 	img.InstallerCustomizations.ISOLabel = labelForISO(&c.SourceInfo.OSRelease, &c.Architecture)
 
-	// XXX workaround for gpt-auto preventing ISO boot see [1]
-	// [1]: https://github.com/osbuild/images/issues/1947#issuecomment-3395867961
-	img.InstallerCustomizations.KernelOptionsAppend = append(img.InstallerCustomizations.KernelOptionsAppend, "systemd.gpt_auto=0")
-
 	img.ExtraBasePackages = rpmmd.PackageSet{
 		Include: imageDef.Packages,
 	}


### PR DESCRIPTION
This reverts commit cce2b81b5eb051e3427ec932c6e87f63f3d17d26. When a new release of images is merged that contains [1] we can push this revert through after verification that the problem remains gone.

[1]: https://github.com/osbuild/images/pull/1949