### PR TITLE
github: use pr.user.login to determine PR author

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -8,7 +8,7 @@ permissions: write-all
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
Using github.actor to determine if a PR was created by dependabot and autoapprove it can be exploited using a "Confused Deputy" attack. Using github.event.pull_request.user.login instead verifies the actual author of the PR.