### PR TITLE
vmtest: switch from rtl8139 to e1000 to avoid silly warnings

### DIFF
--- a/vmtest/vm.py
+++ b/vmtest/vm.py
@@ -144,7 +144,7 @@ class QEMU(VM):
             "-serial", "stdio",
             "-monitor", "none",
             "-netdev", f"user,id=net.0,hostfwd=tcp::{self._ssh_port}-:22",
-            "-device", "rtl8139,netdev=net.0",
+            "-device", "e1000,netdev=net.0",
             "-qmp", f"unix:{self._qmp_socket},server,nowait",
         ]
         if not os.environ.get("OSBUILD_TEST_QEMU_GUI"):


### PR DESCRIPTION
The rtl8139 prints a lot of
```
qemu: Slirp: Failed to send packet, ret: -1
...
```
while booting. This is a bit silly, it just means the system is not ready yet. By switching to the emulated e1000 NIC this won't happen.