### PR TITLE
github: use gobump to update Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,16 +11,3 @@ updates:
       time: "04:00"
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"
-
-  # Maintain dependencies for Go
-  - package-ecosystem: "gomod"
-    directory: "/bib"
-    schedule:
-      interval: "daily"
-      time: "04:00"
-    groups:
-      go-deps:
-        patterns:
-          - "*"  # group all dependency updates into one PR
-    open-pull-requests-limit: 1
-    rebase-strategy: "auto"

--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -1,0 +1,42 @@
+---
+name: "Updates Go dependencies via gobump"
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  schedule:
+    # Every Sunday at 15:00
+    - cron: "0 15 * * 0"
+
+jobs:
+  update-and-push:
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:42
+    steps:
+      - name: Update go.mod and open a PR
+        env:
+          GH_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+        run: |
+          # Install deps
+          set -x
+          sudo dnf -y install git gh golang gpgme-devel btrfs-progs-devel krb5-devel
+          # Checkout the project
+          git clone --depth 1 https://github.com/osbuild/images
+          cd images/
+          # Install and run gobump
+          go run github.com/lzap/gobump@latest -exec "go build ./..." -exec "go test ./..." 2>&1 | tee github_pr_body.txt
+          ./tools/prepare-source.sh
+          # Make a PR when needed
+          if git diff --exit-code; then echo "No changes"; exit 0; fi
+          git config user.name "schutzbot"
+          git config user.email "schutzbot@gmail.com"
+          branch="schutz-gobump-$(date -I)"
+          git checkout -b "${branch}"
+          git add -A
+          git commit -m "build(deps): Update dependencies via gobump"
+          git push -f "https://$GH_TOKEN@github.com/schutzbot/images.git"
+          gh pr create \
+            -t "Update dependencies $(date -I)" \
+            -F "github_pr_body.txt" \
+            --repo "osbuild/images" \
+            --base "main" \
+            --head "schutzbot:${branch}"


### PR DESCRIPTION
SSIA

EDIT:

I disabled MintMaker / Renovate on the repo.  Alternatively, we can enable it again and add a config (`renovate.json`) to do batch updates:
```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "packageRules": [
    {
      "groupName": "go-modules",
      "matchManagers": [
        "gomod"
      ],
      "schedule": [
        "on sunday"
      ]
    }
  ]
}
```