### PR TITLE
added stillOS def

### DIFF
--- a/bib/data/defs/stillos-10.yaml
+++ b/bib/data/defs/stillos-10.yaml
@@ -1,0 +1,1 @@
+bib/data/defs/centos-10.yaml


### PR DESCRIPTION
Hello, this adds a definition file for my distribution stillOS. Upstreaming would be helpful so I don't have to maintain my own docker image just for this overlay. Thanks in advance.