### PR TITLE
go.mod: move to images v0.226.0

### DIFF
--- a/bib/go.mod
+++ b/bib/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/osbuild/blueprint v1.16.0
 	github.com/osbuild/image-builder-cli v0.0.0-20250924085931-15de5139f521
-	github.com/osbuild/images v0.220.0
+	github.com/osbuild/images v0.226.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -249,10 +249,8 @@ github.com/osbuild/blueprint v1.16.0 h1:f/kHih+xpeJ1v7wtIfzdHPZTsiXsqKeDQ1+rrue6
 github.com/osbuild/blueprint v1.16.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
 github.com/osbuild/image-builder-cli v0.0.0-20250924085931-15de5139f521 h1:Mo1htXYyEoKrBQD+/RC/kluAWu4+E0oEjPorujVn/K8=
 github.com/osbuild/image-builder-cli v0.0.0-20250924085931-15de5139f521/go.mod h1:oTn9T+bV9g/760hM/jX7AV0c4vuVIn6FjAnaVM9RzRo=
-github.com/osbuild/images v0.211.0 h1:3BU7mMM7Iu81qZnq7y8luuIIOt707J9tF9DwCyOk9yM=
-github.com/osbuild/images v0.211.0/go.mod h1:Cs7zFV8rmbVHn+19ArNdjd1AtFk+LC9dOOHuxiSLghw=
-github.com/osbuild/images v0.220.0 h1:9aeYxhZ8NxbC1E5Zr5NFYWgG0A5euim4gTwUC08/naQ=
-github.com/osbuild/images v0.220.0/go.mod h1:Cs7zFV8rmbVHn+19ArNdjd1AtFk+LC9dOOHuxiSLghw=
+github.com/osbuild/images v0.226.0 h1:NiryPkd+rx0iPFzKV7s/GP8HPuSuVyXDT2guWVx/i+k=
+github.com/osbuild/images v0.226.0/go.mod h1:Cs7zFV8rmbVHn+19ArNdjd1AtFk+LC9dOOHuxiSLghw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
This will pull in
https://github.com/osbuild/images/pull/2037
to fix a selinux label issue.

Thanks to Alex for fixing this in images.