### PR TITLE
test: ensures right bootc ref after anaconda-iso install ran

### DIFF
--- a/test/test_build_iso.py
+++ b/test/test_build_iso.py
@@ -41,6 +41,8 @@ def test_iso_installs(image_type):
         vm.start(use_ovmf=True)
         vm.run("true", user=image_type.username, password=image_type.password)
         assert_kernel_args(vm, image_type)
+        ret = vm.run(["bootc", "status"], user="root", keyfile=image_type.ssh_keyfile_private_path)
+        assert f"image: {image_type.container_ref}" in ret.stdout
 
 
 def osinfo_for(it: ImageBuildResult, arch: str) -> str:


### PR DESCRIPTION
Our "bootc-installer" image installer checks that after the install bootc status points to the right image. This check is missing currently in the anaconda-iso installer type.

Lets make sure we have it too.

This needs https://github.com/bootc-dev/bootc/pull/1851 to be available.