### PR TITLE
Use ID_LIKE to figure out which bib file to use if a distro def doesn't exist.

### DIFF
--- a/bib/cmd/bootc-image-builder/legacy_iso.go
+++ b/bib/cmd/bootc-image-builder/legacy_iso.go
@@ -270,7 +270,17 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 
 	imageDef, err := distrodef.LoadImageDef(c.DistroDefPaths, c.SourceInfo.OSRelease.ID, c.SourceInfo.OSRelease.VersionID, "anaconda-iso")
 	if err != nil {
-		return nil, err
+		// Try using id_like to pick an image def
+		for _, idLike := range c.SourceInfo.OSRelease.IDLike {
+			logrus.Warnf("Could not load image def for %s, trying %s: %v", c.SourceInfo.OSRelease.ID, idLike, err)
+			imageDef, err = distrodef.LoadImageDef(c.DistroDefPaths, idLike, c.SourceInfo.OSRelease.VersionID, "anaconda-iso")
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	containerSource := container.SourceSpec{

--- a/bib/data/defs/stillos-10.yaml
+++ b/bib/data/defs/stillos-10.yaml
@@ -1,1 +1,0 @@
-bib/data/defs/centos-10.yaml


### PR DESCRIPTION
Also remove stillOS symlink as this commit removes the need for it.

I wanted to have a visible warning if this occurred, although I could not figure out how to display that in the CLI other than just adding it as a warning to the logs.