### PR TITLE
Support root-less containers with --in-vm

### DIFF
--- a/bib/cmd/bootc-image-builder/main.go
+++ b/bib/cmd/bootc-image-builder/main.go
@@ -268,7 +268,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	runInVM, _ := cmd.Flags().GetBool("in-vm")
 
 	logrus.Debug("Validating environment")
-	if err := setup.Validate(targetArch); err != nil {
+	if err := setup.Validate(targetArch, runInVM); err != nil {
 		return fmt.Errorf("cannot validate the setup: %w", err)
 	}
 	logrus.Debug("Ensuring environment setup")
@@ -276,7 +276,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	case false:
 		fmt.Fprintf(os.Stderr, "WARNING: running outside a container, this is an unsupported configuration\n")
 	case true:
-		if err := setup.EnsureEnvironment(osbuildStore); err != nil {
+		if err := setup.EnsureEnvironment(osbuildStore, runInVM); err != nil {
 			return fmt.Errorf("cannot ensure the environment: %w", err)
 		}
 	}

--- a/bib/go.mod
+++ b/bib/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/hashicorp/go-version v1.7.0
 	github.com/osbuild/blueprint v1.22.0
-	github.com/osbuild/image-builder-cli v0.0.0-20260126184006-13a177bf6bf7
+	github.com/osbuild/image-builder-cli v0.0.0-20260129132320-81814bf8e883
 	github.com/osbuild/images v0.234.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2

--- a/bib/go.sum
+++ b/bib/go.sum
@@ -247,8 +247,8 @@ github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplU
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/osbuild/blueprint v1.22.0 h1:b3WicGjCFzEwOm/YwPH7w9YioCcehGejdOTkjJ3Fyz0=
 github.com/osbuild/blueprint v1.22.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/image-builder-cli v0.0.0-20260126184006-13a177bf6bf7 h1:ruEgBtwjQCxdisAdv2vfrZ2Fks5AcPOe+H8mFbSCUi4=
-github.com/osbuild/image-builder-cli v0.0.0-20260126184006-13a177bf6bf7/go.mod h1:ER0gpmtXw+KL24UICAzSPO+1W3g777n+KfDplGL6olw=
+github.com/osbuild/image-builder-cli v0.0.0-20260129132320-81814bf8e883 h1:QGZdlpTtkMYyqI1GY7gJIo9/9jy7eqeQVKJCW2qyN8E=
+github.com/osbuild/image-builder-cli v0.0.0-20260129132320-81814bf8e883/go.mod h1:ER0gpmtXw+KL24UICAzSPO+1W3g777n+KfDplGL6olw=
 github.com/osbuild/images v0.234.0 h1:8RrUzOxR2/rYk7ErWxiEJ5mTWZ0yEbjRXsbvT8hnPf0=
 github.com/osbuild/images v0.234.0/go.mod h1:vjzHaL/8MDG6c3yjU8qgMKOIib89A1r2ql50Nronaw4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
This updates to the latest image-builder-cli, adding support for rootless container use
(https://github.com/osbuild/image-builder-cli/pull/445).

It also updates the use of related APIs to pass runInVm options where needed.

With this, I was able to run a rootless bc-i-b conversion. There is one problem, which is that if you mount ~/.local/share/containers/storage on the host to /var/lib/containers/storage in the contained, podman will complain with:

Error: database static dir "~/.local/share/containers/storage/libpod" does not match our static dir "/var/lib/containers/storage/libpod": database configuration mismatch

Additionally, if you pass the host "/var/lib/containers/storage" into the rootless container you will get read permission errors.

There are two workarounds for this. Either you can use e.g. skopeo to copy the bootc container to a separate (non-root) container storage directory and mount that, or you can cover the "db.sql" file in the storage directory to make podman not print the error.

Neither of these are super clean, and we should try to figure out a better solution, but for now I was at least able to run a complete image build using:

```
$ touch /tmp/foo
$ podman run --rm --security-opt label=type:unconfined_t -ti --privileged \
  --network=none -v $PWD/output:/output \
  -v ~/.local/share/containers/storage:/var/lib/containers/storage \
  -v /tmp/foo:/var/lib/containers/storage/db.sql \
  localhost/bootc-image-builder  --in-vm \
  --rootfs ext4 --type raw \
  quay.io/fedora/fedora-bootc:43
```